### PR TITLE
Fix: stabilize queues and UI metrics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "scripts": {
         "test": "phpunit",
         "cs": "php-cs-fixer fix --diff",
-        "stan": "phpstan analyse src --level=5 --memory-limit=256M"
+        "stan": "phpstan analyse src --level=5 --memory-limit=256M",
+        "db:create": "php tools/db/create-database.php"
     },
     "config": {
         "sort-packages": true

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -3,13 +3,27 @@
 use App\Infrastructure\Container\Container;
 use App\Infrastructure\Http\Kernel;
 use App\Infrastructure\Http\Router;
+use DateTimeZone;
 use Dotenv\Dotenv;
+use Exception;
+use RuntimeException;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 Dotenv::createImmutable(dirname(__DIR__))->safeLoad();
 
 $parameters = require __DIR__ . '/parameters.php';
+
+$timezone = $parameters['app.timezone'] ?? 'UTC';
+
+try {
+    new DateTimeZone($timezone);
+} catch (Exception $exception) {
+    throw new RuntimeException(sprintf('Invalid application timezone "%s".', $timezone), 0, $exception);
+}
+
+date_default_timezone_set($timezone);
+
 $container = new Container($parameters);
 
 $servicesConfigurator = require __DIR__ . '/services.php';

--- a/config/parameters.php
+++ b/config/parameters.php
@@ -4,6 +4,7 @@ return [
     'app.env' => $_ENV['APP_ENV'] ?? 'prod',
     'app.debug' => (bool) ($_ENV['APP_DEBUG'] ?? false),
     'app.base_url' => $_ENV['BASE_URL'] ?? 'http://localhost:8000',
+    'app.timezone' => $_ENV['APP_TIMEZONE'] ?? 'Europe/Paris',
     'db.host' => $_ENV['DB_HOST'] ?? '127.0.0.1',
     'db.port' => (int) ($_ENV['DB_PORT'] ?? 3306),
     'db.name' => $_ENV['DB_NAME'] ?? 'genesis_reborn',

--- a/config/routes.php
+++ b/config/routes.php
@@ -7,6 +7,7 @@ use App\Controller\FleetController;
 use App\Controller\JournalController;
 use App\Controller\ProfileController;
 use App\Controller\ResearchController;
+use App\Controller\ResourceApiController;
 use App\Controller\ShipyardController;
 use App\Controller\TechTreeController;
 use App\Infrastructure\Http\Router;
@@ -38,4 +39,6 @@ return function (Router $router): void {
     $router->add('GET', '/profile', [ProfileController::class, 'index']);
 
     $router->add('GET', '/tech-tree', [TechTreeController::class, 'index']);
+
+    $router->add('GET', '/api/resources', [ResourceApiController::class, 'show']);
 };

--- a/config/services.php
+++ b/config/services.php
@@ -40,6 +40,7 @@ use App\Domain\Service\FleetNavigationService;
 use App\Domain\Service\FleetResolutionService;
 use App\Domain\Service\ResearchCalculator;
 use App\Domain\Service\ResearchCatalog;
+use App\Domain\Service\ResourceEffectFactory;
 use App\Domain\Service\ResourceTickService;
 use App\Domain\Service\ShipCatalog;
 use App\Infrastructure\Container\Container;
@@ -88,7 +89,12 @@ return function (Container $container): void {
 
     $container->set(BuildingCalculator::class, fn () => new BuildingCalculator());
 
-    $container->set(ResourceTickService::class, fn () => new ResourceTickService());
+    $container->set(ResourceTickService::class, function () {
+        $config = require __DIR__ . '/game/buildings.php';
+        $effects = ResourceEffectFactory::fromBuildingConfig($config);
+
+        return new ResourceTickService($effects);
+    });
     $container->set(CostService::class, fn () => new CostService());
     $container->set(FleetNavigationService::class, fn () => new FleetNavigationService());
     $container->set(FleetResolutionService::class, fn () => new FleetResolutionService());
@@ -287,6 +293,8 @@ return function (Container $container): void {
         $c->get(ProcessBuildQueue::class),
         $c->get(ProcessResearchQueue::class),
         $c->get(ProcessShipBuildQueue::class),
+        $c->get(BuildingStateRepositoryInterface::class),
+        $c->get(ResourceTickService::class),
         $c->get(ViewRenderer::class),
         $c->get(SessionInterface::class),
         $c->get(FlashBag::class),

--- a/config/services.php
+++ b/config/services.php
@@ -21,12 +21,14 @@ use App\Controller\FleetController;
 use App\Controller\JournalController;
 use App\Controller\ProfileController;
 use App\Controller\ResearchController;
+use App\Controller\ResourceApiController;
 use App\Controller\ShipyardController;
 use App\Controller\TechTreeController;
 use App\Domain\Repository\BuildingStateRepositoryInterface;
 use App\Domain\Repository\BuildQueueRepositoryInterface;
 use App\Domain\Repository\FleetRepositoryInterface;
 use App\Domain\Repository\PlanetRepositoryInterface;
+use App\Domain\Repository\PlayerStatsRepositoryInterface;
 use App\Domain\Repository\ResearchQueueRepositoryInterface;
 use App\Domain\Repository\ResearchStateRepositoryInterface;
 use App\Domain\Repository\ShipBuildQueueRepositoryInterface;
@@ -50,6 +52,7 @@ use App\Infrastructure\Persistence\PdoBuildQueueRepository;
 use App\Infrastructure\Persistence\PdoBuildingStateRepository;
 use App\Infrastructure\Persistence\PdoFleetRepository;
 use App\Infrastructure\Persistence\PdoPlanetRepository;
+use App\Infrastructure\Persistence\PdoPlayerStatsRepository;
 use App\Infrastructure\Persistence\PdoResearchQueueRepository;
 use App\Infrastructure\Persistence\PdoResearchStateRepository;
 use App\Infrastructure\Persistence\PdoShipBuildQueueRepository;
@@ -106,6 +109,7 @@ return function (Container $container): void {
 
     $container->set(UserRepositoryInterface::class, fn (Container $c) => new PdoUserRepository($c->get(\PDO::class)));
     $container->set(PlanetRepositoryInterface::class, fn (Container $c) => new PdoPlanetRepository($c->get(\PDO::class)));
+    $container->set(PlayerStatsRepositoryInterface::class, fn (Container $c) => new PdoPlayerStatsRepository($c->get(\PDO::class)));
     $container->set(BuildingStateRepositoryInterface::class, fn (Container $c) => new PdoBuildingStateRepository($c->get(\PDO::class)));
     $container->set(BuildQueueRepositoryInterface::class, fn (Container $c) => new PdoBuildQueueRepository($c->get(\PDO::class)));
     $container->set(ResearchQueueRepositoryInterface::class, fn (Container $c) => new PdoResearchQueueRepository($c->get(\PDO::class)));
@@ -145,6 +149,7 @@ return function (Container $container): void {
         $c->get(BuildQueueRepositoryInterface::class),
         $c->get(ResearchQueueRepositoryInterface::class),
         $c->get(ShipBuildQueueRepositoryInterface::class),
+        $c->get(PlayerStatsRepositoryInterface::class),
         $c->get(ResearchStateRepositoryInterface::class),
         $c->get(FleetRepositoryInterface::class),
         $c->get(BuildingCatalog::class),
@@ -169,6 +174,7 @@ return function (Container $container): void {
         $c->get(PlanetRepositoryInterface::class),
         $c->get(BuildingStateRepositoryInterface::class),
         $c->get(BuildQueueRepositoryInterface::class),
+        $c->get(PlayerStatsRepositoryInterface::class),
         $c->get(BuildingCatalog::class),
         $c->get(BuildingCalculator::class)
     ));
@@ -188,6 +194,7 @@ return function (Container $container): void {
         $c->get(BuildingStateRepositoryInterface::class),
         $c->get(ResearchStateRepositoryInterface::class),
         $c->get(ResearchQueueRepositoryInterface::class),
+        $c->get(PlayerStatsRepositoryInterface::class),
         $c->get(ResearchCatalog::class),
         $c->get(ResearchCalculator::class)
     ));
@@ -215,6 +222,7 @@ return function (Container $container): void {
         $c->get(BuildingStateRepositoryInterface::class),
         $c->get(ResearchStateRepositoryInterface::class),
         $c->get(ShipBuildQueueRepositoryInterface::class),
+        $c->get(PlayerStatsRepositoryInterface::class),
         $c->get(ShipCatalog::class)
     ));
 
@@ -266,6 +274,18 @@ return function (Container $container): void {
         $c->get(PlanetRepositoryInterface::class),
         $c->get(GetShipyardOverview::class),
         $c->get(BuildShips::class),
+        $c->get(ProcessShipBuildQueue::class),
+        $c->get(ViewRenderer::class),
+        $c->get(SessionInterface::class),
+        $c->get(FlashBag::class),
+        $c->get(CsrfTokenManager::class),
+        $c->getParameter('app.base_url')
+    ));
+
+    $container->set(ResourceApiController::class, fn (Container $c) => new ResourceApiController(
+        $c->get(PlanetRepositoryInterface::class),
+        $c->get(ProcessBuildQueue::class),
+        $c->get(ProcessResearchQueue::class),
         $c->get(ProcessShipBuildQueue::class),
         $c->get(ViewRenderer::class),
         $c->get(SessionInterface::class),

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,9 @@ tests (PHPUnit)
 composer install
 composer dump-autoload --optimize
 
+# Base de données
+composer db:create
+
 # QA & tests
 composer test
 composer stan
@@ -133,16 +136,9 @@ npm run svgo:build
 ---
 
 ## Bugs connus & TODO
-- **Header** : ne s’actualise pas avec les ressources → rafraîchissement auto à implémenter.
 - **Files d’attente** :
     - Construction & recherches doivent être **séquentielles** (5 max).
     - Les niveaux doivent s’enchaîner correctement (mine lvl1 → lvl2).
-- **Arbre techno** : afficher les prérequis (valides = vert, invalides = gris avec niveau actuel/requis).
-- **Vue d’ensemble** : remplacer nombre de planètes colonisées par **puissance scientifique**
-    - Formule : `1 point = 1000 ressources dépensées`.
-- **Dashboard** :
-    - Supprimer : niveaux de recherche, bloc recherche scientifique, bloc force spatiale.
-    - Déplacer "recherches en cours" → section "productions en cours".
 
 ---
 

--- a/migrations/20250922_add_science_spent_to_players.sql
+++ b/migrations/20250922_add_science_spent_to_players.sql
@@ -1,0 +1,2 @@
+ALTER TABLE players
+    ADD COLUMN science_spent BIGINT UNSIGNED NOT NULL DEFAULT 0 AFTER password_hash;

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -767,8 +767,8 @@ main.workspace__content {
 }
 
 .production-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    display: flex;
+    flex-direction: column;
     gap: var(--space-4);
 }
 

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -1029,6 +1029,15 @@ main.workspace__content {
     border-color: rgba(100, 180, 255, 0.4);
 }
 
+.tech-node-link--ready {
+    border-color: rgba(120, 220, 170, 0.45);
+    background: rgba(120, 220, 170, 0.1);
+}
+
+.tech-node-link--ready .tech-node-link__level {
+    color: var(--color-success);
+}
+
 .tech-node-link__label {
     text-align: left;
 }
@@ -1304,6 +1313,7 @@ main.workspace__content {
     border-radius: var(--radius-sm);
     border: 1px solid transparent;
     font-size: var(--font-size-sm);
+    transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .flash--success {
@@ -1322,6 +1332,11 @@ main.workspace__content {
     background: var(--info-soft);
     border-color: var(--info-border);
     color: var(--color-text);
+}
+
+.flash.is-hidden {
+    opacity: 0;
+    transform: translateY(-4px);
 }
 
 .logout-form {
@@ -1434,6 +1449,14 @@ main.workspace__content {
         display: none;
     }
 
+}
+
+.queue-block {
+    display: block;
+}
+
+.queue-block .empty-state {
+    margin: 0;
 }
 
 .queue-list {

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -6,6 +6,250 @@ const escapeHtml = (value) => String(value ?? '').replace(/[&<>'"]/g, (char) => 
     "'": '&#039;',
 }[char] || char));
 
+const numberFormatter = new Intl.NumberFormat('fr-FR');
+
+const formatNumber = (value) => {
+    const numericValue = typeof value === 'number' ? value : Number(value ?? 0);
+
+    return numberFormatter.format(Number.isFinite(numericValue) ? numericValue : 0);
+};
+
+const formatSeconds = (value) => {
+    const seconds = Math.max(0, Math.floor(Number(value ?? 0)));
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const remainingSeconds = seconds % 60;
+    const parts = [];
+    if (hours > 0) {
+        parts.push(`${hours} h`);
+    }
+    if (minutes > 0) {
+        parts.push(`${minutes} min`);
+    }
+    if (parts.length === 0 || remainingSeconds > 0) {
+        parts.push(`${remainingSeconds} s`);
+    }
+
+    return parts.join(' ');
+};
+
+const updateResourceMeters = (resources = {}) => {
+    Object.entries(resources).forEach(([key, data]) => {
+        const meter = document.querySelector(`.resource-meter[data-resource="${CSS.escape(key)}"]`);
+        if (!meter) {
+            return;
+        }
+
+        const valueElement = meter.querySelector('[data-resource-value]');
+        const rateElement = meter.querySelector('[data-resource-rate]');
+        const value = data && typeof data === 'object' ? data.value ?? 0 : 0;
+        const perHour = data && typeof data === 'object' ? data.perHour ?? 0 : 0;
+
+        if (valueElement) {
+            valueElement.textContent = formatNumber(value);
+        }
+
+        if (rateElement) {
+            const ratePrefix = key !== 'energy' && perHour > 0 ? '+' : '';
+            rateElement.textContent = `${ratePrefix}${formatNumber(perHour)}/h`;
+            rateElement.classList.toggle('is-positive', perHour >= 0);
+            rateElement.classList.toggle('is-negative', perHour < 0);
+        }
+    });
+};
+
+const renderQueue = (queue, target) => {
+    const container = document.querySelector(`[data-queue="${CSS.escape(target)}"]`);
+    if (!container) {
+        return;
+    }
+
+    const emptyMessage = container.dataset.empty || 'Aucune action en cours.';
+    if (!queue || !Array.isArray(queue.jobs) || queue.jobs.length === 0) {
+        container.innerHTML = `<p class="empty-state">${escapeHtml(emptyMessage)}</p>`;
+        return;
+    }
+
+    const items = queue.jobs.map((job) => {
+        const label = escapeHtml(job.label ?? job.building ?? job.research ?? job.ship ?? '');
+        const remaining = formatSeconds(job.remaining ?? 0);
+        const endsAt = job.endsAt ? new Date(job.endsAt) : null;
+        const timeHtml = endsAt && !Number.isNaN(endsAt.getTime())
+            ? `<time datetime="${endsAt.toISOString()}">${endsAt.toLocaleString('fr-FR', {
+                day: '2-digit',
+                month: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+            })}</time>`
+            : '';
+
+        let detail = '';
+        if (target === 'shipyard') {
+            const quantity = formatNumber(job.quantity ?? 0);
+            detail = `${quantity} unité(s)`;
+        } else {
+            const level = formatNumber(job.targetLevel ?? 0);
+            detail = `Niveau ${level}`;
+        }
+
+        return `
+            <li class="queue-list__item">
+                <div><strong>${label}</strong><span>${detail}</span></div>
+                <div class="queue-list__timing">
+                    <span>Termine dans ${escapeHtml(remaining)}</span>
+                    ${timeHtml}
+                </div>
+            </li>
+        `;
+    }).join('');
+
+    container.innerHTML = `<ul class="queue-list">${items}</ul>`;
+};
+
+const ensureFlashContainer = () => {
+    let container = document.querySelector('.flashes');
+    if (!container) {
+        const mainContent = document.querySelector('.workspace__content');
+        container = document.createElement('div');
+        container.className = 'flashes';
+        if (mainContent) {
+            mainContent.prepend(container);
+        }
+    }
+
+    return container;
+};
+
+const showFlashMessage = (type, message) => {
+    if (!message) {
+        return;
+    }
+
+    const container = ensureFlashContainer();
+    const flash = document.createElement('div');
+    flash.className = `flash flash--${type}`;
+    flash.textContent = message;
+    container.appendChild(flash);
+
+    window.setTimeout(() => {
+        flash.classList.add('is-hidden');
+        window.setTimeout(() => {
+            flash.remove();
+        }, 400);
+    }, 5000);
+};
+
+const submitAsyncForm = async (form) => {
+    const action = form.getAttribute('action') || window.location.href;
+    const method = (form.getAttribute('method') || 'POST').toUpperCase();
+    const formData = new FormData(form);
+    const submitButton = form.querySelector('[type="submit"]');
+    const buttonWasDisabled = submitButton?.disabled ?? false;
+    if (submitButton) {
+        submitButton.disabled = true;
+    }
+
+    try {
+        const response = await fetch(action, {
+            method,
+            body: formData,
+            headers: {
+                Accept: 'application/json',
+            },
+            credentials: 'same-origin',
+        });
+        const data = await response.json().catch(() => null);
+
+        if (!data) {
+            throw new Error('Invalid JSON response');
+        }
+
+        if (!response.ok || data.success === false) {
+            showFlashMessage('danger', data.message ?? 'Action impossible.');
+            if (data.resources) {
+                updateResourceMeters(data.resources);
+            }
+            if (form.dataset.queueTarget && data.queue) {
+                renderQueue(data.queue, form.dataset.queueTarget);
+            }
+
+            return;
+        }
+
+        showFlashMessage('success', data.message ?? 'Action effectuée.');
+        if (data.resources) {
+            updateResourceMeters(data.resources);
+        }
+        if (form.dataset.queueTarget && data.queue) {
+            renderQueue(data.queue, form.dataset.queueTarget);
+        }
+        if (typeof data.planetId === 'number') {
+            const topbar = document.querySelector('.topbar[data-resource-endpoint]');
+            if (topbar) {
+                topbar.dataset.planetId = String(data.planetId);
+            }
+        }
+    } catch (_error) {
+        showFlashMessage('danger', 'Impossible de traiter votre demande pour le moment.');
+    } finally {
+        if (submitButton && !buttonWasDisabled) {
+            submitButton.disabled = false;
+        }
+    }
+};
+
+const initAsyncForms = () => {
+    const forms = document.querySelectorAll('form[data-async]');
+    forms.forEach((form) => {
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            submitAsyncForm(form);
+        });
+    });
+};
+
+const initResourcePolling = () => {
+    const topbar = document.querySelector('.topbar[data-resource-endpoint]');
+    if (!topbar) {
+        return;
+    }
+
+    const endpoint = topbar.dataset.resourceEndpoint || '';
+    const pollDelay = Number(topbar.dataset.resourcePoll || 0);
+    let planetId = Number(topbar.dataset.planetId || 0);
+
+    if (!endpoint || !pollDelay || planetId <= 0) {
+        return;
+    }
+
+    const fetchResources = async () => {
+        planetId = Number(topbar.dataset.planetId || planetId);
+        if (planetId <= 0) {
+            return;
+        }
+
+        try {
+            const url = new URL(endpoint, window.location.origin);
+            url.searchParams.set('planet', String(planetId));
+            const response = await fetch(url.toString(), {
+                headers: {
+                    Accept: 'application/json',
+                },
+                credentials: 'same-origin',
+            });
+            const data = await response.json().catch(() => null);
+            if (data?.success && data.resources) {
+                updateResourceMeters(data.resources);
+            }
+        } catch (_error) {
+            // Ignore polling errors silently.
+        }
+    };
+
+    fetchResources();
+    window.setInterval(fetchResources, pollDelay);
+};
+
 const initSidebar = () => {
     const sidebar = document.querySelector('[data-sidebar]');
     if (!sidebar) {
@@ -169,6 +413,7 @@ const initTechTree = () => {
     };
 
     nodeLinks.forEach((link) => {
+        link.classList.toggle('tech-node-link--ready', link.dataset.techReady === '1');
         link.addEventListener('click', () => {
             const target = link.dataset.techTarget || '';
             if (target !== '') {
@@ -191,6 +436,8 @@ const initTechTree = () => {
 const ready = () => {
     initSidebar();
     initAutoSubmitSelects();
+    initAsyncForms();
+    initResourcePolling();
     initTechTree();
 };
 

--- a/src/Application/UseCase/Building/UpgradeBuilding.php
+++ b/src/Application/UseCase/Building/UpgradeBuilding.php
@@ -2,9 +2,11 @@
 
 namespace App\Application\UseCase\Building;
 
+use App\Domain\Entity\Planet;
 use App\Domain\Repository\BuildingStateRepositoryInterface;
 use App\Domain\Repository\BuildQueueRepositoryInterface;
 use App\Domain\Repository\PlanetRepositoryInterface;
+use App\Domain\Repository\PlayerStatsRepositoryInterface;
 use App\Domain\Service\BuildingCalculator;
 use App\Domain\Service\BuildingCatalog;
 
@@ -14,6 +16,7 @@ class UpgradeBuilding
         private readonly PlanetRepositoryInterface $planets,
         private readonly BuildingStateRepositoryInterface $buildingStates,
         private readonly BuildQueueRepositoryInterface $buildQueue,
+        private readonly PlayerStatsRepositoryInterface $playerStats,
         private readonly BuildingCatalog $catalog,
         private readonly BuildingCalculator $calculator
     ) {
@@ -31,20 +34,35 @@ class UpgradeBuilding
         $levels = $this->buildingStates->getLevels($planetId);
         $currentLevel = $levels[$buildingKey] ?? 0;
 
+        if ($this->buildQueue->countActive($planetId) >= 5) {
+            return ['success' => false, 'message' => 'La file de construction est pleine (5 actions maximum).'];
+        }
+
+        $existingJobs = $this->buildQueue->getActiveQueue($planetId);
+        $queuedOccurrences = 0;
+        foreach ($existingJobs as $job) {
+            if ($job->getBuildingKey() === $buildingKey) {
+                ++$queuedOccurrences;
+            }
+        }
+
+        $targetLevel = $currentLevel + $queuedOccurrences + 1;
+
         $requirements = $this->calculator->checkRequirements($definition, $levels, []);
         if (!$requirements['ok']) {
             return ['success' => false, 'message' => 'Pré-requis manquants.'];
         }
 
-        $cost = $this->calculator->nextCost($definition, $currentLevel);
+        $cost = $this->calculator->nextCost($definition, $targetLevel - 1);
         if (!$this->canAfford($planet, $cost)) {
             return ['success' => false, 'message' => 'Ressources insuffisantes.'];
         }
 
         $this->deductCost($planet, $cost);
 
-        $duration = $this->calculator->nextTime($definition, $currentLevel);
-        $this->buildQueue->enqueue($planetId, $buildingKey, $currentLevel + 1, $duration);
+        $duration = $this->calculator->nextTime($definition, $targetLevel - 1);
+        $this->buildQueue->enqueue($planetId, $buildingKey, $targetLevel, $duration);
+        $this->playerStats->addScienceSpending($userId, $this->sumCost($cost));
         $this->planets->update($planet);
 
         return ['success' => true, 'message' => 'Construction planifiée.'];
@@ -53,7 +71,7 @@ class UpgradeBuilding
     /**
      * @param array<string, int> $cost
      */
-    private function canAfford(\App\Domain\Entity\Planet $planet, array $cost): bool
+    private function canAfford(Planet $planet, array $cost): bool
     {
         foreach ($cost as $resource => $amount) {
             if ($amount <= 0) {
@@ -78,7 +96,7 @@ class UpgradeBuilding
     /**
      * @param array<string, int> $cost
      */
-    private function deductCost(\App\Domain\Entity\Planet $planet, array $cost): void
+    private function deductCost(Planet $planet, array $cost): void
     {
         foreach ($cost as $resource => $amount) {
             if ($amount <= 0) {
@@ -99,4 +117,18 @@ class UpgradeBuilding
         }
     }
 
+    /**
+     * @param array<string, int> $cost
+     */
+    private function sumCost(array $cost): int
+    {
+        $total = 0;
+        foreach ($cost as $amount) {
+            if ($amount > 0) {
+                $total += (int) $amount;
+            }
+        }
+
+        return $total;
+    }
 }

--- a/src/Application/UseCase/Dashboard/GetDashboard.php
+++ b/src/Application/UseCase/Dashboard/GetDashboard.php
@@ -61,7 +61,8 @@ class GetDashboard
         $planets = $this->planets->findByUser($userId);
         $planetSummaries = [];
         $totals = ['metal' => 0, 'crystal' => 0, 'hydrogen' => 0, 'energy' => 0];
-        $empirePoints = 0;
+        $buildingPoints = 0;
+        $sciencePoints = 0;
         $researchSum = 0;
         $unlockedResearch = 0;
         $highestTech = ['label' => 'Aucune technologie', 'level' => 0];
@@ -110,9 +111,13 @@ class GetDashboard
             $totals['hydrogen'] += $planet->getHydrogen();
             $totals['energy'] += $planet->getEnergy();
 
-            $empirePoints += array_sum($levels) + array_sum($researchLevels);
+            $buildingTotal = array_sum($levels);
+            $researchTotal = array_sum($researchLevels);
 
-            $researchSum += array_sum($researchLevels);
+            $buildingPoints += $buildingTotal;
+            $sciencePoints += $researchTotal;
+
+            $researchSum += $researchTotal;
             $unlockedResearch += count(array_filter($researchLevels, static fn (int $level): bool => $level > 0));
             foreach ($researchLevels as $researchKey => $researchLevel) {
                 if ($researchLevel <= $highestTech['level']) {
@@ -182,6 +187,8 @@ class GetDashboard
         $scienceSpent = $this->playerStats->getScienceSpending($userId);
         $sciencePower = (int) floor($scienceSpent / 1000);
 
+        $empireScore = $buildingPoints + $sciencePoints + $militaryPower;
+
         return [
             'planets' => $planetSummaries,
             'totals' => $totals,
@@ -191,7 +198,10 @@ class GetDashboard
                 'best' => $highestTech,
             ],
             'empire' => [
-                'points' => $empirePoints,
+                'points' => $empireScore,
+                'buildingPoints' => $buildingPoints,
+                'sciencePoints' => $sciencePoints,
+                'militaryPoints' => $militaryPower,
                 'militaryPower' => $militaryPower,
                 'planetCount' => count($planets),
                 'scienceSpent' => $scienceSpent,

--- a/src/Application/UseCase/Dashboard/GetDashboard.php
+++ b/src/Application/UseCase/Dashboard/GetDashboard.php
@@ -9,6 +9,7 @@ use App\Domain\Repository\BuildingStateRepositoryInterface;
 use App\Domain\Repository\BuildQueueRepositoryInterface;
 use App\Domain\Repository\FleetRepositoryInterface;
 use App\Domain\Repository\PlanetRepositoryInterface;
+use App\Domain\Repository\PlayerStatsRepositoryInterface;
 use App\Domain\Repository\ResearchQueueRepositoryInterface;
 use App\Domain\Repository\ResearchStateRepositoryInterface;
 use App\Domain\Repository\ShipBuildQueueRepositoryInterface;
@@ -26,6 +27,7 @@ class GetDashboard
         private readonly BuildQueueRepositoryInterface $buildQueue,
         private readonly ResearchQueueRepositoryInterface $researchQueue,
         private readonly ShipBuildQueueRepositoryInterface $shipQueue,
+        private readonly PlayerStatsRepositoryInterface $playerStats,
         private readonly ResearchStateRepositoryInterface $researchStates,
         private readonly FleetRepositoryInterface $fleets,
         private readonly BuildingCatalog $catalog,
@@ -177,6 +179,9 @@ class GetDashboard
             ];
         }
 
+        $scienceSpent = $this->playerStats->getScienceSpending($userId);
+        $sciencePower = (int) floor($scienceSpent / 1000);
+
         return [
             'planets' => $planetSummaries,
             'totals' => $totals,
@@ -189,6 +194,8 @@ class GetDashboard
                 'points' => $empirePoints,
                 'militaryPower' => $militaryPower,
                 'planetCount' => count($planets),
+                'scienceSpent' => $scienceSpent,
+                'sciencePower' => $sciencePower,
             ],
         ];
     }

--- a/src/Application/UseCase/Research/StartResearch.php
+++ b/src/Application/UseCase/Research/StartResearch.php
@@ -4,6 +4,7 @@ namespace App\Application\UseCase\Research;
 
 use App\Domain\Repository\BuildingStateRepositoryInterface;
 use App\Domain\Repository\PlanetRepositoryInterface;
+use App\Domain\Repository\PlayerStatsRepositoryInterface;
 use App\Domain\Repository\ResearchQueueRepositoryInterface;
 use App\Domain\Repository\ResearchStateRepositoryInterface;
 use App\Domain\Service\ResearchCalculator;
@@ -16,6 +17,7 @@ class StartResearch
         private readonly BuildingStateRepositoryInterface $buildingStates,
         private readonly ResearchStateRepositoryInterface $researchStates,
         private readonly ResearchQueueRepositoryInterface $researchQueue,
+        private readonly PlayerStatsRepositoryInterface $playerStats,
         private readonly ResearchCatalog $catalog,
         private readonly ResearchCalculator $calculator
     ) {
@@ -34,7 +36,24 @@ class StartResearch
         $researchLevels = $this->researchStates->getLevels($planetId);
         $currentLevel = $researchLevels[$researchKey] ?? 0;
 
-        if ($currentLevel >= $definition->getMaxLevel()) {
+        if ($currentLevel >= $definition->getMaxLevel() && $definition->getMaxLevel() > 0) {
+            return ['success' => false, 'message' => 'Ce domaine scientifique a atteint son niveau maximal.'];
+        }
+
+        if ($this->researchQueue->countActive($planetId) >= 5) {
+            return ['success' => false, 'message' => 'La file de recherche est pleine (5 programmes maximum).'];
+        }
+
+        $queuedOccurrences = 0;
+        foreach ($this->researchQueue->getActiveQueue($planetId) as $job) {
+            if ($job->getResearchKey() === $researchKey) {
+                ++$queuedOccurrences;
+            }
+        }
+
+        $targetLevel = $currentLevel + $queuedOccurrences + 1;
+        $maxLevel = $definition->getMaxLevel();
+        if ($maxLevel > 0 && $targetLevel > $maxLevel) {
             return ['success' => false, 'message' => 'Ce domaine scientifique a atteint son niveau maximal.'];
         }
 
@@ -49,14 +68,15 @@ class StartResearch
             return ['success' => false, 'message' => 'Pré-requis de recherche manquants.'];
         }
 
-        $cost = $this->calculator->nextCost($definition, $currentLevel);
+        $cost = $this->calculator->nextCost($definition, $targetLevel - 1);
         if (!$this->canAfford($planet, $cost)) {
             return ['success' => false, 'message' => 'Ressources insuffisantes pour lancer cette recherche.'];
         }
 
         $this->deductCost($planet, $cost);
-        $duration = $this->calculator->nextTime($definition, $currentLevel);
-        $this->researchQueue->enqueue($planetId, $researchKey, $currentLevel + 1, $duration);
+        $duration = $this->calculator->nextTime($definition, $targetLevel - 1);
+        $this->researchQueue->enqueue($planetId, $researchKey, $targetLevel, $duration);
+        $this->playerStats->addScienceSpending($userId, $this->sumCost($cost));
         $this->planets->update($planet);
 
         return ['success' => true, 'message' => 'Recherche planifiée.'];
@@ -109,5 +129,20 @@ class StartResearch
                     break;
             }
         }
+    }
+
+    /**
+     * @param array<string, int> $cost
+     */
+    private function sumCost(array $cost): int
+    {
+        $total = 0;
+        foreach ($cost as $amount) {
+            if ($amount > 0) {
+                $total += (int) $amount;
+            }
+        }
+
+        return $total;
     }
 }

--- a/src/Application/UseCase/Shipyard/GetShipyardOverview.php
+++ b/src/Application/UseCase/Shipyard/GetShipyardOverview.php
@@ -77,12 +77,14 @@ class GetShipyardOverview
             ];
         }
 
+        $queueLimitReached = count($queueJobs) >= 5;
+
         $categories = [];
         foreach ($this->catalog->groupedByCategory() as $category => $data) {
             $items = [];
             foreach ($data['items'] as $definition) {
                 $requirements = $this->checkRequirements($definition->getRequiresResearch(), $researchLevels, $catalogMap);
-                $canBuild = $shipyardLevel > 0 && $requirements['ok'];
+                $canBuild = $shipyardLevel > 0 && $requirements['ok'] && !$queueLimitReached;
 
                 $items[] = [
                     'definition' => $definition,

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -7,6 +7,7 @@ use App\Infrastructure\Http\ViewRenderer;
 use App\Infrastructure\Http\Session\FlashBag;
 use App\Infrastructure\Http\Session\SessionInterface;
 use App\Infrastructure\Security\CsrfTokenManager;
+use RuntimeException;
 
 abstract class AbstractController
 {
@@ -24,6 +25,17 @@ abstract class AbstractController
         $content = $this->renderer->render($template, $parameters);
 
         return new Response($content, $status);
+    }
+
+    protected function json(array $data, int $status = 200): Response
+    {
+        try {
+            $payload = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        } catch (\JsonException $exception) {
+            throw new RuntimeException('Impossible de sérialiser la réponse JSON.', 0, $exception);
+        }
+
+        return (new Response($payload, $status))->addHeader('Content-Type', 'application/json');
     }
 
     protected function redirect(string $path): Response

--- a/src/Controller/ResearchController.php
+++ b/src/Controller/ResearchController.php
@@ -73,11 +73,31 @@ class ResearchController extends AbstractController
         if ($request->getMethod() === 'POST') {
             $data = $request->getBodyParams();
             if (!$this->isCsrfTokenValid('start_research_' . $selectedId, $data['csrf_token'] ?? null)) {
+                if ($request->wantsJson()) {
+                    return $this->json([
+                        'success' => false,
+                        'message' => 'Session expirée, veuillez réessayer.',
+                    ], 400);
+                }
+
                 $this->addFlash('danger', 'Session expirée, veuillez réessayer.');
                 return $this->redirect($this->baseUrl . '/research?planet=' . $selectedId);
             }
 
             $result = $this->startResearch->execute($selectedId, $userId, $data['research'] ?? '');
+            if ($request->wantsJson()) {
+                $overview = $this->getOverview->execute($selectedId);
+                $planet = $overview['planet'];
+
+                return $this->json([
+                    'success' => $result['success'],
+                    'message' => $result['message'] ?? ($result['success'] ? 'Recherche planifiée.' : 'Action impossible.'),
+                    'resources' => $this->formatResourceSnapshot($planet),
+                    'queue' => $overview['queue'],
+                    'planetId' => $selectedId,
+                ], $result['success'] ? 200 : 400);
+            }
+
             if ($result['success']) {
                 $this->addFlash('success', $result['message'] ?? 'Recherche planifiée.');
             } else {
@@ -112,5 +132,15 @@ class ResearchController extends AbstractController
             'activeSection' => 'research',
             'activePlanetSummary' => $activePlanetSummary,
         ]);
+    }
+
+    private function formatResourceSnapshot(\App\Domain\Entity\Planet $planet): array
+    {
+        return [
+            'metal' => ['value' => $planet->getMetal(), 'perHour' => $planet->getMetalPerHour()],
+            'crystal' => ['value' => $planet->getCrystal(), 'perHour' => $planet->getCrystalPerHour()],
+            'hydrogen' => ['value' => $planet->getHydrogen(), 'perHour' => $planet->getHydrogenPerHour()],
+            'energy' => ['value' => $planet->getEnergy(), 'perHour' => $planet->getEnergyPerHour()],
+        ];
     }
 }

--- a/src/Controller/ResourceApiController.php
+++ b/src/Controller/ResourceApiController.php
@@ -5,13 +5,16 @@ namespace App\Controller;
 use App\Application\Service\ProcessBuildQueue;
 use App\Application\Service\ProcessResearchQueue;
 use App\Application\Service\ProcessShipBuildQueue;
+use App\Domain\Repository\BuildingStateRepositoryInterface;
 use App\Domain\Repository\PlanetRepositoryInterface;
+use App\Domain\Service\ResourceTickService;
 use App\Infrastructure\Http\Request;
 use App\Infrastructure\Http\Response;
 use App\Infrastructure\Http\Session\FlashBag;
 use App\Infrastructure\Http\Session\SessionInterface;
 use App\Infrastructure\Http\ViewRenderer;
 use App\Infrastructure\Security\CsrfTokenManager;
+use DateTimeImmutable;
 
 class ResourceApiController extends AbstractController
 {
@@ -20,6 +23,8 @@ class ResourceApiController extends AbstractController
         private readonly ProcessBuildQueue $buildQueue,
         private readonly ProcessResearchQueue $researchQueue,
         private readonly ProcessShipBuildQueue $shipQueue,
+        private readonly BuildingStateRepositoryInterface $buildingStates,
+        private readonly ResourceTickService $resourceTickService,
         ViewRenderer $renderer,
         SessionInterface $session,
         FlashBag $flashBag,
@@ -60,6 +65,87 @@ class ResourceApiController extends AbstractController
         $this->shipQueue->process($planetId);
 
         $planet = $this->planets->find($planetId) ?? $planet;
+
+        $buildingLevels = $this->buildingStates->getLevels($planetId);
+        $now = new DateTimeImmutable();
+
+        $tickStates = [
+            $planetId => [
+                'planet_id' => $planetId,
+                'player_id' => $userId,
+                'resources' => [
+                    'metal' => $planet->getMetal(),
+                    'crystal' => $planet->getCrystal(),
+                    'hydrogen' => $planet->getHydrogen(),
+                    'energy' => $planet->getEnergy(),
+                ],
+                'capacities' => [
+                    'metal' => $planet->getMetalCapacity(),
+                    'crystal' => $planet->getCrystalCapacity(),
+                    'hydrogen' => $planet->getHydrogenCapacity(),
+                    'energy' => $planet->getEnergyCapacity(),
+                ],
+                'last_tick' => $planet->getLastResourceTick(),
+                'building_levels' => $buildingLevels,
+            ],
+        ];
+
+        $tickResults = $this->resourceTickService->tick($tickStates, $now);
+        $planetTick = $tickResults[$planetId] ?? null;
+
+        if ($planetTick !== null) {
+            $elapsed = (int) $planetTick['elapsed_seconds'];
+
+            /** @var array<string, int> $resources */
+            $resources = $planetTick['resources'];
+            if (isset($resources['metal'])) {
+                $planet->setMetal((int) $resources['metal']);
+            }
+            if (isset($resources['crystal'])) {
+                $planet->setCrystal((int) $resources['crystal']);
+            }
+            if (isset($resources['hydrogen'])) {
+                $planet->setHydrogen((int) $resources['hydrogen']);
+            }
+            if (isset($resources['energy'])) {
+                $planet->setEnergy((int) $resources['energy']);
+            }
+
+            /** @var array<string, int> $production */
+            $production = $planetTick['production_per_hour'];
+            if (isset($production['metal'])) {
+                $planet->setMetalPerHour((int) $production['metal']);
+            }
+            if (isset($production['crystal'])) {
+                $planet->setCrystalPerHour((int) $production['crystal']);
+            }
+            if (isset($production['hydrogen'])) {
+                $planet->setHydrogenPerHour((int) $production['hydrogen']);
+            }
+            if (isset($production['energy'])) {
+                $planet->setEnergyPerHour((int) $production['energy']);
+            }
+
+            /** @var array<string, int> $capacities */
+            $capacities = $planetTick['capacities'];
+            if (isset($capacities['metal'])) {
+                $planet->setMetalCapacity((int) $capacities['metal']);
+            }
+            if (isset($capacities['crystal'])) {
+                $planet->setCrystalCapacity((int) $capacities['crystal']);
+            }
+            if (isset($capacities['hydrogen'])) {
+                $planet->setHydrogenCapacity((int) $capacities['hydrogen']);
+            }
+            if (isset($capacities['energy'])) {
+                $planet->setEnergyCapacity((int) $capacities['energy']);
+            }
+
+            if ($elapsed > 0) {
+                $planet->setLastResourceTick($now);
+                $this->planets->update($planet);
+            }
+        }
 
         return $this->json([
             'success' => true,

--- a/src/Controller/ResourceApiController.php
+++ b/src/Controller/ResourceApiController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Controller;
+
+use App\Application\Service\ProcessBuildQueue;
+use App\Application\Service\ProcessResearchQueue;
+use App\Application\Service\ProcessShipBuildQueue;
+use App\Domain\Repository\PlanetRepositoryInterface;
+use App\Infrastructure\Http\Request;
+use App\Infrastructure\Http\Response;
+use App\Infrastructure\Http\Session\FlashBag;
+use App\Infrastructure\Http\Session\SessionInterface;
+use App\Infrastructure\Http\ViewRenderer;
+use App\Infrastructure\Security\CsrfTokenManager;
+
+class ResourceApiController extends AbstractController
+{
+    public function __construct(
+        private readonly PlanetRepositoryInterface $planets,
+        private readonly ProcessBuildQueue $buildQueue,
+        private readonly ProcessResearchQueue $researchQueue,
+        private readonly ProcessShipBuildQueue $shipQueue,
+        ViewRenderer $renderer,
+        SessionInterface $session,
+        FlashBag $flashBag,
+        CsrfTokenManager $csrfTokenManager,
+        string $baseUrl
+    ) {
+        parent::__construct($renderer, $session, $flashBag, $csrfTokenManager, $baseUrl);
+    }
+
+    public function show(Request $request): Response
+    {
+        $userId = $this->getUserId();
+        if (!$userId) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Authentification requise.',
+            ], 401);
+        }
+
+        $planetId = (int) ($request->getQueryParams()['planet'] ?? 0);
+        if ($planetId <= 0) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Planète invalide.',
+            ], 400);
+        }
+
+        $planet = $this->planets->find($planetId);
+        if (!$planet || $planet->getUserId() !== $userId) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Planète introuvable.',
+            ], 404);
+        }
+
+        $this->buildQueue->process($planetId);
+        $this->researchQueue->process($planetId);
+        $this->shipQueue->process($planetId);
+
+        $planet = $this->planets->find($planetId) ?? $planet;
+
+        return $this->json([
+            'success' => true,
+            'planetId' => $planetId,
+            'resources' => [
+                'metal' => ['value' => $planet->getMetal(), 'perHour' => $planet->getMetalPerHour()],
+                'crystal' => ['value' => $planet->getCrystal(), 'perHour' => $planet->getCrystalPerHour()],
+                'hydrogen' => ['value' => $planet->getHydrogen(), 'perHour' => $planet->getHydrogenPerHour()],
+                'energy' => ['value' => $planet->getEnergy(), 'perHour' => $planet->getEnergyPerHour()],
+            ],
+        ]);
+    }
+}

--- a/src/Domain/Entity/Planet.php
+++ b/src/Domain/Entity/Planet.php
@@ -2,8 +2,12 @@
 
 namespace App\Domain\Entity;
 
+use DateTimeImmutable;
+
 class Planet
 {
+    private DateTimeImmutable $lastResourceTick;
+
     public function __construct(
         private readonly int $id,
         private readonly int $userId,
@@ -18,8 +22,14 @@ class Planet
         private int $metalPerHour,
         private int $crystalPerHour,
         private int $hydrogenPerHour,
-        private int $energyPerHour
+        private int $energyPerHour,
+        private int $metalCapacity,
+        private int $crystalCapacity,
+        private int $hydrogenCapacity,
+        private int $energyCapacity,
+        ?DateTimeImmutable $lastResourceTick = null
     ) {
+        $this->lastResourceTick = $lastResourceTick ?? new DateTimeImmutable();
     }
 
     public function getId(): int
@@ -147,5 +157,55 @@ class Planet
     public function setEnergyPerHour(int $value): void
     {
         $this->energyPerHour = $value;
+    }
+
+    public function getMetalCapacity(): int
+    {
+        return $this->metalCapacity;
+    }
+
+    public function setMetalCapacity(int $value): void
+    {
+        $this->metalCapacity = $value;
+    }
+
+    public function getCrystalCapacity(): int
+    {
+        return $this->crystalCapacity;
+    }
+
+    public function setCrystalCapacity(int $value): void
+    {
+        $this->crystalCapacity = $value;
+    }
+
+    public function getHydrogenCapacity(): int
+    {
+        return $this->hydrogenCapacity;
+    }
+
+    public function setHydrogenCapacity(int $value): void
+    {
+        $this->hydrogenCapacity = $value;
+    }
+
+    public function getEnergyCapacity(): int
+    {
+        return $this->energyCapacity;
+    }
+
+    public function setEnergyCapacity(int $value): void
+    {
+        $this->energyCapacity = $value;
+    }
+
+    public function getLastResourceTick(): DateTimeImmutable
+    {
+        return $this->lastResourceTick;
+    }
+
+    public function setLastResourceTick(DateTimeImmutable $lastResourceTick): void
+    {
+        $this->lastResourceTick = $lastResourceTick;
     }
 }

--- a/src/Domain/Repository/PlayerStatsRepositoryInterface.php
+++ b/src/Domain/Repository/PlayerStatsRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\Repository;
+
+interface PlayerStatsRepositoryInterface
+{
+    public function addScienceSpending(int $playerId, int $amount): void;
+
+    public function getScienceSpending(int $playerId): int;
+}

--- a/src/Domain/Service/ResourceEffectFactory.php
+++ b/src/Domain/Service/ResourceEffectFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Domain\Service;
+
+final class ResourceEffectFactory
+{
+    /**
+     * @param array<string, array<string, mixed>> $buildingConfig
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function fromBuildingConfig(array $buildingConfig): array
+    {
+        $effects = [];
+
+        foreach ($buildingConfig as $key => $data) {
+            if (!is_array($data)) {
+                continue;
+            }
+
+            $effect = [];
+            $affects = $data['affects'] ?? null;
+
+            $productionBase = (float) ($data['prod_base'] ?? 0);
+            $productionGrowth = (float) ($data['prod_growth'] ?? 1);
+            $energyUseBase = (float) ($data['energy_use_base'] ?? 0);
+            $energyUseGrowth = (float) ($data['energy_use_growth'] ?? 1);
+            $energyUseLinear = !empty($data['energy_use_linear']);
+
+            if (in_array($affects, ['metal', 'crystal', 'hydrogen'], true) && $productionBase > 0) {
+                $effect['produces'][$affects] = [
+                    'base' => $productionBase,
+                    'growth' => $productionGrowth,
+                ];
+            } elseif ($affects === 'energy' && $productionBase > 0) {
+                $effect['energy']['production'] = [
+                    'base' => $productionBase,
+                    'growth' => $productionGrowth,
+                ];
+            }
+
+            if ($energyUseBase !== 0.0) {
+                $effect['energy']['consumption'] = [
+                    'base' => $energyUseBase,
+                    'growth' => $energyUseGrowth,
+                ];
+                if ($energyUseLinear) {
+                    $effect['energy']['consumption']['linear'] = true;
+                }
+            }
+
+            if (!empty($data['storage']) && is_array($data['storage'])) {
+                foreach ($data['storage'] as $resourceKey => $storageConfig) {
+                    if (!is_array($storageConfig)) {
+                        continue;
+                    }
+
+                    $effect['storage'][$resourceKey] = [
+                        'base' => (float) ($storageConfig['base'] ?? 0),
+                        'growth' => (float) ($storageConfig['growth'] ?? 1),
+                    ];
+                }
+            }
+
+            if ($effect !== []) {
+                $effects[$key] = $effect;
+            }
+        }
+
+        return $effects;
+    }
+}

--- a/src/Infrastructure/Database/ConnectionFactory.php
+++ b/src/Infrastructure/Database/ConnectionFactory.php
@@ -2,7 +2,10 @@
 
 namespace App\Infrastructure\Database;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use PDO;
+use PDOException;
 
 class ConnectionFactory
 {
@@ -19,9 +22,51 @@ class ConnectionFactory
     {
         $dsn = sprintf('mysql:host=%s;port=%d;dbname=%s;charset=utf8mb4', $this->host, $this->port, $this->dbName);
 
-        return new PDO($dsn, $this->user, $this->password, [
+        $pdo = new PDO($dsn, $this->user, $this->password, [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         ]);
+
+        if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql') {
+            $timezoneId = date_default_timezone_get();
+
+            try {
+                $this->applyTimezone($pdo, $timezoneId);
+            } catch (PDOException $exception) {
+                $offset = $this->formatOffset($timezoneId);
+
+                if ($offset === null) {
+                    throw $exception;
+                }
+
+                $this->applyTimezone($pdo, $offset);
+            }
+        }
+
+        return $pdo;
+    }
+
+    private function applyTimezone(PDO $pdo, string $timezone): void
+    {
+        $statement = $pdo->prepare('SET time_zone = :timezone');
+        $statement->execute(['timezone' => $timezone]);
+    }
+
+    private function formatOffset(string $timezoneId): ?string
+    {
+        try {
+            $timezone = new DateTimeZone($timezoneId);
+        } catch (\Exception) {
+            return null;
+        }
+
+        $now = new DateTimeImmutable('now', $timezone);
+        $offsetInSeconds = $timezone->getOffset($now);
+        $sign = $offsetInSeconds >= 0 ? '+' : '-';
+        $absoluteOffset = abs($offsetInSeconds);
+        $hours = intdiv($absoluteOffset, 3600);
+        $minutes = intdiv($absoluteOffset % 3600, 60);
+
+        return sprintf('%s%02d:%02d', $sign, $hours, $minutes);
     }
 }

--- a/src/Infrastructure/Http/Request.php
+++ b/src/Infrastructure/Http/Request.php
@@ -13,7 +13,8 @@ class Request
         private readonly string $path,
         private readonly array $query,
         private readonly array $body,
-        public readonly Session $session
+        public readonly Session $session,
+        private readonly array $headers = []
     ) {
     }
 
@@ -32,12 +33,31 @@ class Request
             $session = new Session($storage);
         }
 
+        $headers = [];
+        foreach ($_SERVER as $key => $value) {
+            if (!is_string($key) || !is_scalar($value)) {
+                continue;
+            }
+
+            if (str_starts_with($key, 'HTTP_')) {
+                $headerName = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))));
+                $headers[$headerName] = (string) $value;
+            }
+        }
+
+        foreach (['CONTENT_TYPE' => 'Content-Type', 'CONTENT_LENGTH' => 'Content-Length'] as $serverKey => $headerName) {
+            if (isset($_SERVER[$serverKey]) && is_scalar($_SERVER[$serverKey])) {
+                $headers[$headerName] = (string) $_SERVER[$serverKey];
+            }
+        }
+
         return new self(
             strtoupper($method),
             $path,
             $_GET,
             $_POST,
-            $session
+            $session,
+            $headers
         );
     }
 
@@ -48,7 +68,8 @@ class Request
             $this->path,
             $this->query,
             $this->body,
-            $session
+            $session,
+            $this->headers
         );
         $clone->attributes = $this->attributes;
 
@@ -103,5 +124,34 @@ class Request
     public function getAttributes(): array
     {
         return $this->attributes;
+    }
+
+    public function getHeader(string $name): ?string
+    {
+        $normalized = strtolower($name);
+        foreach ($this->headers as $headerName => $value) {
+            if (strtolower($headerName) === $normalized) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    public function wantsJson(): bool
+    {
+        $accept = strtolower($this->getHeader('Accept') ?? '');
+        if ($accept !== '' && str_contains($accept, 'application/json')) {
+            return true;
+        }
+
+        $requestedWith = strtolower($this->getHeader('X-Requested-With') ?? '');
+
+        return $requestedWith === 'xmlhttprequest';
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
     }
 }

--- a/src/Infrastructure/Persistence/PdoPlanetRepository.php
+++ b/src/Infrastructure/Persistence/PdoPlanetRepository.php
@@ -4,6 +4,7 @@ namespace App\Infrastructure\Persistence;
 
 use App\Domain\Entity\Planet;
 use App\Domain\Repository\PlanetRepositoryInterface;
+use DateTimeImmutable;
 use PDO;
 use PDOException;
 use RuntimeException;
@@ -110,7 +111,9 @@ class PdoPlanetRepository implements PlanetRepositoryInterface
     public function update(Planet $planet): void
     {
         $stmt = $this->pdo->prepare('UPDATE planets SET name = :name, metal = :metal, crystal = :crystal, hydrogen = :hydrogen, energy = :energy,
-            prod_metal_per_hour = :mPH, prod_crystal_per_hour = :cPH, prod_hydrogen_per_hour = :hPH, prod_energy_per_hour = :ePH WHERE id = :id');
+            prod_metal_per_hour = :mPH, prod_crystal_per_hour = :cPH, prod_hydrogen_per_hour = :hPH, prod_energy_per_hour = :ePH,
+            metal_capacity = :metalCapacity, crystal_capacity = :crystalCapacity, hydrogen_capacity = :hydrogenCapacity, energy_capacity = :energyCapacity,
+            last_resource_tick = :lastTick WHERE id = :id');
 
         $stmt->execute([
             'name' => $planet->getName(),
@@ -122,6 +125,11 @@ class PdoPlanetRepository implements PlanetRepositoryInterface
             'cPH' => $planet->getCrystalPerHour(),
             'hPH' => $planet->getHydrogenPerHour(),
             'ePH' => $planet->getEnergyPerHour(),
+            'metalCapacity' => $planet->getMetalCapacity(),
+            'crystalCapacity' => $planet->getCrystalCapacity(),
+            'hydrogenCapacity' => $planet->getHydrogenCapacity(),
+            'energyCapacity' => $planet->getEnergyCapacity(),
+            'lastTick' => $planet->getLastResourceTick()->format('Y-m-d H:i:s'),
             'id' => $planet->getId(),
         ]);
     }
@@ -154,7 +162,12 @@ class PdoPlanetRepository implements PlanetRepositoryInterface
             (int) ($data['prod_metal_per_hour'] ?? 0),
             (int) ($data['prod_crystal_per_hour'] ?? 0),
             (int) ($data['prod_hydrogen_per_hour'] ?? 0),
-            (int) ($data['prod_energy_per_hour'] ?? 0)
+            (int) ($data['prod_energy_per_hour'] ?? 0),
+            (int) ($data['metal_capacity'] ?? 0),
+            (int) ($data['crystal_capacity'] ?? 0),
+            (int) ($data['hydrogen_capacity'] ?? 0),
+            (int) ($data['energy_capacity'] ?? 0),
+            isset($data['last_resource_tick']) ? new DateTimeImmutable($data['last_resource_tick']) : null
         );
     }
 }

--- a/src/Infrastructure/Persistence/PdoPlanetRepository.php
+++ b/src/Infrastructure/Persistence/PdoPlanetRepository.php
@@ -67,9 +67,11 @@ class PdoPlanetRepository implements PlanetRepositoryInterface
             $hydrogenCapacity = 40000;
             $energyCapacity = 1000;
 
+            $now = new DateTimeImmutable('now');
+
             $this->pdo->prepare(
                 'INSERT INTO planets (player_id, name, galaxy, `system`, `position`, diameter, temperature_min, temperature_max, is_homeworld, metal, crystal, hydrogen, prod_metal_per_hour, prod_crystal_per_hour, prod_hydrogen_per_hour, prod_energy_per_hour, energy, metal_capacity, crystal_capacity, hydrogen_capacity, energy_capacity, last_resource_tick, created_at, updated_at)
-                VALUES (:player, :name, :galaxy, :system, :position, :diameter, :tmin, :tmax, 1, :metal, :crystal, :hydrogen, :mPH, :cPH, :hPH, :ePH, :energy, :metalCap, :crystalCap, :hydrogenCap, :energyCap, NOW(), NOW(), NOW())'
+                VALUES (:player, :name, :galaxy, :system, :position, :diameter, :tmin, :tmax, 1, :metal, :crystal, :hydrogen, :mPH, :cPH, :hPH, :ePH, :energy, :metalCap, :crystalCap, :hydrogenCap, :energyCap, :now, :now, :now)'
             )->execute([
                 'player' => $userId,
                 'name' => 'Planète mère',
@@ -91,6 +93,7 @@ class PdoPlanetRepository implements PlanetRepositoryInterface
                 'crystalCap' => $crystalCapacity,
                 'hydrogenCap' => $hydrogenCapacity,
                 'energyCap' => $energyCapacity,
+                'now' => $now->format('Y-m-d H:i:s'),
             ]);
 
             $id = (int) $this->pdo->lastInsertId();

--- a/src/Infrastructure/Persistence/PdoPlayerStatsRepository.php
+++ b/src/Infrastructure/Persistence/PdoPlayerStatsRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Infrastructure\Persistence;
+
+use App\Domain\Repository\PlayerStatsRepositoryInterface;
+use PDO;
+
+class PdoPlayerStatsRepository implements PlayerStatsRepositoryInterface
+{
+    public function __construct(private readonly PDO $pdo)
+    {
+    }
+
+    public function addScienceSpending(int $playerId, int $amount): void
+    {
+        if ($amount <= 0) {
+            return;
+        }
+
+        $stmt = $this->pdo->prepare('UPDATE players SET science_spent = science_spent + :amount WHERE id = :id');
+        $stmt->execute([
+            'amount' => $amount,
+            'id' => $playerId,
+        ]);
+    }
+
+    public function getScienceSpending(int $playerId): int
+    {
+        $stmt = $this->pdo->prepare('SELECT science_spent FROM players WHERE id = :id');
+        $stmt->execute(['id' => $playerId]);
+        $value = $stmt->fetchColumn();
+
+        return $value !== false ? (int) $value : 0;
+    }
+}

--- a/templates/colony/index.php
+++ b/templates/colony/index.php
@@ -12,7 +12,6 @@ $queue = $overview['queue'] ?? ['count' => 0, 'jobs' => []];
 $buildings = $overview['buildings'] ?? [];
 
 $icon = require __DIR__ . '/../components/_icon.php';
-$resourceBar = require __DIR__ . '/../components/_resource_bar.php';
 $card = require __DIR__ . '/../components/_card.php';
 
 if (!function_exists('format_duration')) {
@@ -44,17 +43,6 @@ $resourceLabels = [
     'hydrogen' => 'Hydrogène',
     'energy' => 'Énergie',
 ];
-
-$resourceSummaryData = [];
-if (is_array($activePlanetSummary)) {
-    foreach ($activePlanetSummary['resources'] as $key => $data) {
-        $resourceSummaryData[$key] = [
-            'label' => $resourceLabels[$key] ?? ucfirst((string) $key),
-            'value' => $data['value'] ?? 0,
-            'perHour' => $data['perHour'] ?? 0,
-        ];
-    }
-}
 
 $assetBase = rtrim($baseUrl, '/');
 
@@ -94,16 +82,6 @@ ob_start();
         },
     ]) ?>
 <?php else: ?>
-    <?php if ($resourceSummaryData !== []): ?>
-        <?= $card([
-            'title' => 'Ressources planétaires',
-            'subtitle' => 'Production horaire actuelle',
-            'body' => static function () use ($resourceBar, $resourceSummaryData, $baseUrl): void {
-                echo $resourceBar($resourceSummaryData, ['baseUrl' => $baseUrl]);
-            },
-        ]) ?>
-    <?php endif; ?>
-
     <?= $card([
         'title' => 'File de construction',
         'subtitle' => 'Suivi des améliorations en cours',

--- a/templates/colony/index.php
+++ b/templates/colony/index.php
@@ -108,26 +108,27 @@ ob_start();
         'title' => 'File de construction',
         'subtitle' => 'Suivi des améliorations en cours',
         'body' => static function () use ($queue): void {
+            $emptyMessage = 'Aucune amélioration n’est programmée. Lancez une construction pour développer votre colonie.';
+            echo '<div class="queue-block" data-queue="buildings" data-empty="' . htmlspecialchars($emptyMessage, ENT_QUOTES) . '">';
             if (($queue['count'] ?? 0) === 0) {
-                echo '<p class="empty-state">Aucune amélioration n’est programmée. Lancez une construction pour développer votre colonie.</p>';
-
-                return;
-            }
-
-            echo '<ul class="queue-list">';
-            foreach ($queue['jobs'] as $job) {
-                $label = $job['label'] ?? $job['building'] ?? '';
-                echo '<li class="queue-list__item">';
-                echo '<div><strong>' . htmlspecialchars((string) $label) . '</strong><span>Niveau ' . number_format((int) ($job['targetLevel'] ?? 0)) . '</span></div>';
-                echo '<div class="queue-list__timing">';
-                echo '<span>Termine dans ' . htmlspecialchars(format_duration((int) ($job['remaining'] ?? 0))) . '</span>';
-                if (!empty($job['endsAt']) && $job['endsAt'] instanceof \DateTimeImmutable) {
-                    echo '<time datetime="' . $job['endsAt']->format('c') . '">' . $job['endsAt']->format('d/m H:i') . '</time>';
+                echo '<p class="empty-state">' . htmlspecialchars($emptyMessage) . '</p>';
+            } else {
+                echo '<ul class="queue-list">';
+                foreach ($queue['jobs'] as $job) {
+                    $label = $job['label'] ?? $job['building'] ?? '';
+                    echo '<li class="queue-list__item">';
+                    echo '<div><strong>' . htmlspecialchars((string) $label) . '</strong><span>Niveau ' . number_format((int) ($job['targetLevel'] ?? 0)) . '</span></div>';
+                    echo '<div class="queue-list__timing">';
+                    echo '<span>Termine dans ' . htmlspecialchars(format_duration((int) ($job['remaining'] ?? 0))) . '</span>';
+                    if (!empty($job['endsAt']) && $job['endsAt'] instanceof \DateTimeImmutable) {
+                        echo '<time datetime="' . $job['endsAt']->format('c') . '">' . $job['endsAt']->format('d/m H:i') . '</time>';
+                    }
+                    echo '</div>';
+                    echo '</li>';
                 }
-                echo '</div>';
-                echo '</li>';
+                echo '</ul>';
             }
-            echo '</ul>';
+            echo '</div>';
         },
     ]) ?>
 
@@ -198,7 +199,7 @@ ob_start();
                         return;
                     }
 
-                    echo '<form method="post" action="' . htmlspecialchars($baseUrl) . '/colony?planet=' . $planet->getId() . '">';
+                    echo '<form method="post" action="' . htmlspecialchars($baseUrl) . '/colony?planet=' . $planet->getId() . '" data-async="queue" data-queue-target="buildings">';
                     echo '<input type="hidden" name="csrf_token" value="' . htmlspecialchars((string) $csrf_upgrade) . '">';
                     echo '<input type="hidden" name="building" value="' . htmlspecialchars($definition->getKey()) . '">';
                     $label = $canUpgrade ? 'Améliorer' : 'Conditions non remplies';

--- a/templates/fleet/index.php
+++ b/templates/fleet/index.php
@@ -14,7 +14,6 @@
 
 $title = $title ?? 'Flotte';
 $icon = require __DIR__ . '/../components/_icon.php';
-$resourceBar = require __DIR__ . '/../components/_resource_bar.php';
 $card = require __DIR__ . '/../components/_card.php';
 
 if (!function_exists('format_duration')) {
@@ -37,18 +36,6 @@ if (!function_exists('format_duration')) {
         }
 
         return implode(' ', $parts);
-    }
-}
-
-$resourceSummaryData = [];
-if (is_array($activePlanetSummary)) {
-    $labels = ['metal' => 'Métal', 'crystal' => 'Cristal', 'hydrogen' => 'Hydrogène', 'energy' => 'Énergie'];
-    foreach ($activePlanetSummary['resources'] as $key => $data) {
-        $resourceSummaryData[$key] = [
-            'label' => $labels[$key] ?? ucfirst((string) $key),
-            'value' => $data['value'] ?? 0,
-            'perHour' => $data['perHour'] ?? 0,
-        ];
     }
 }
 
@@ -77,16 +64,6 @@ ob_start();
         <?php endif; ?>
     </div>
 </section>
-
-<?php if ($resourceSummaryData !== []): ?>
-    <?= $card([
-        'title' => 'Ressources disponibles',
-        'subtitle' => 'Nécessaires au lancement des missions',
-        'body' => static function () use ($resourceBar, $resourceSummaryData, $baseUrl): void {
-            echo $resourceBar($resourceSummaryData, ['baseUrl' => $baseUrl]);
-        },
-    ]) ?>
-<?php endif; ?>
 
 <?= $card([
     'title' => 'Flotte stationnée',

--- a/templates/journal/index.php
+++ b/templates/journal/index.php
@@ -8,20 +8,7 @@
 
 $title = $title ?? 'Journal de bord';
 $icon = require __DIR__ . '/../components/_icon.php';
-$resourceBar = require __DIR__ . '/../components/_resource_bar.php';
 $card = require __DIR__ . '/../components/_card.php';
-
-$resourceSummaryData = [];
-if (is_array($activePlanetSummary)) {
-    $labels = ['metal' => 'Métal', 'crystal' => 'Cristal', 'hydrogen' => 'Hydrogène', 'energy' => 'Énergie'];
-    foreach ($activePlanetSummary['resources'] as $key => $data) {
-        $resourceSummaryData[$key] = [
-            'label' => $labels[$key] ?? ucfirst((string) $key),
-            'value' => $data['value'] ?? 0,
-            'perHour' => $data['perHour'] ?? 0,
-        ];
-    }
-}
 
 ob_start();
 ?>
@@ -43,16 +30,6 @@ ob_start();
         <?php endif; ?>
     </div>
 </section>
-
-<?php if ($resourceSummaryData !== []): ?>
-    <?= $card([
-        'title' => 'Résumé des ressources',
-        'subtitle' => 'Statut actuel de la colonie',
-        'body' => static function () use ($resourceBar, $resourceSummaryData, $baseUrl): void {
-            echo $resourceBar($resourceSummaryData, ['baseUrl' => $baseUrl]);
-        },
-    ]) ?>
-<?php endif; ?>
 
 <?= $card([
     'title' => 'Statistiques des files',

--- a/templates/layouts/base.php
+++ b/templates/layouts/base.php
@@ -34,6 +34,8 @@ if (is_array($activePlanetSummary) && isset($activePlanetSummary['planet']) && $
 $activePlanetName = $activePlanet ? $activePlanet->getName() : 'Planète active';
 $currentPlanetId = $selectedPlanetId ?? ($activePlanet ? $activePlanet->getId() : null);
 $resourceSummary = is_array($activePlanetSummary) ? ($activePlanetSummary['resources'] ?? []) : [];
+$resourceEndpoint = $baseUrl . '/api/resources';
+$resourcePlanetId = $currentPlanetId ?? 0;
 
 $menu = [
     'dashboard' => ['label' => 'Tableau de bord', 'path' => '/dashboard', 'icon' => 'overview'],
@@ -80,7 +82,7 @@ $currentSectionPath = $menu[$activeSection]['path'] ?? '/dashboard';
         <div class="sidebar-overlay" data-sidebar-overlay></div>
     <?php endif; ?>
     <div class="workspace">
-        <header class="topbar <?= $isAuthenticated ? '' : 'topbar--guest' ?>">
+        <header class="topbar <?= $isAuthenticated ? '' : 'topbar--guest' ?>"<?= $isAuthenticated ? ' data-resource-endpoint="' . htmlspecialchars($resourceEndpoint) . '" data-planet-id="' . (int) $resourcePlanetId . '" data-resource-poll="15000"' : '' ?>>
             <?php if ($isAuthenticated): ?>
                 <div class="topbar__primary">
                     <button class="topbar__menu" type="button" aria-label="Ouvrir la navigation" data-sidebar-toggle aria-controls="primary-sidebar" aria-expanded="false">
@@ -111,7 +113,7 @@ $currentSectionPath = $menu[$activeSection]['path'] ?? '/dashboard';
                         $rateDisplay = $ratePrefix . $rateNumber . '/h';
                         $rateClass = $perHourValue >= 0 ? 'is-positive' : 'is-negative';
                         ?>
-                        <div class="resource-meter" role="group" aria-label="<?= htmlspecialchars($label) ?>">
+                        <div class="resource-meter" role="group" aria-label="<?= htmlspecialchars($label) ?>" data-resource="<?= htmlspecialchars($key) ?>">
                             <div class="resource-meter__icon">
                                 <svg class="icon icon-sm" aria-hidden="true">
                                     <use href="<?= htmlspecialchars($baseUrl) ?>/assets/svg/sprite.svg#icon-<?= htmlspecialchars($key) ?>"></use>
@@ -120,8 +122,8 @@ $currentSectionPath = $menu[$activeSection]['path'] ?? '/dashboard';
                             <div class="resource-meter__details">
                                 <span class="resource-meter__label"><?= htmlspecialchars($label) ?></span>
                                 <div class="resource-meter__values">
-                                    <span class="resource-meter__value"><?= number_format((int) ($data['value'] ?? 0)) ?></span>
-                                    <span class="resource-meter__rate <?= $rateClass ?>"><?= htmlspecialchars($rateDisplay) ?></span>
+                                    <span class="resource-meter__value" data-resource-value><?= number_format((int) ($data['value'] ?? 0)) ?></span>
+                                    <span class="resource-meter__rate <?= $rateClass ?>" data-resource-rate><?= htmlspecialchars($rateDisplay) ?></span>
                                 </div>
                             </div>
                         </div>

--- a/templates/pages/dashboard/index.php
+++ b/templates/pages/dashboard/index.php
@@ -31,7 +31,14 @@ if (!function_exists('format_duration')) {
     }
 }
 
-$empire = $dashboard['empire'] ?? ['points' => 0, 'militaryPower' => 0, 'planetCount' => 0];
+$empire = $dashboard['empire'] ?? [
+    'points' => 0,
+    'buildingPoints' => 0,
+    'sciencePoints' => 0,
+    'militaryPoints' => 0,
+    'militaryPower' => 0,
+    'planetCount' => 0,
+];
 $planetSummaries = $dashboard['planets'] ?? [];
 $selectedPlanetId = $selectedPlanetId ?? null;
 if ($selectedPlanetId === null && $activePlanetSummary) {
@@ -76,11 +83,7 @@ ob_start();
                 <strong class="dashboard-banner__value"><?= $activePlanet ? htmlspecialchars($activePlanet->getName()) : 'Aucune planète' ?></strong>
             </li>
             <li>
-                <span class="dashboard-banner__label">Puissance scientifique</span>
-                <strong class="dashboard-banner__value"><?= number_format($empire['sciencePower'] ?? 0) ?></strong>
-            </li>
-            <li>
-                <span class="dashboard-banner__label">Points d’empire</span>
+                <span class="dashboard-banner__label">Score impérial</span>
                 <strong class="dashboard-banner__value"><?= number_format($empire['points'] ?? 0) ?></strong>
             </li>
         </ul>
@@ -90,30 +93,35 @@ ob_start();
             <article class="panel panel--highlight">
                 <header class="panel__header">
                     <h2>Vue d’ensemble</h2>
-                    <p class="panel__subtitle">Bilan rapide de votre progression impériale.</p>
+                    <p class="panel__subtitle">Synthèse des forces civiles, scientifiques et militaires.</p>
                 </header>
                 <div class="panel__body metrics metrics--compact">
                     <div class="metric">
-                        <span class="metric__label">Points d’empire</span>
+                        <span class="metric__label">Score impérial</span>
                         <strong class="metric__value"><?= number_format($empire['points'] ?? 0) ?></strong>
-                        <span class="metric__hint">Somme des niveaux de bâtiments et de recherches.</span>
+                        <span class="metric__hint">Bâtiments + recherches + puissance militaire.</span>
                     </div>
                     <div class="metric">
-                        <span class="metric__label">Puissance scientifique</span>
-                        <strong class="metric__value"><?= number_format($empire['sciencePower'] ?? 0) ?></strong>
-                        <span class="metric__hint">1 point = 1 000 ressources investies dans vos programmes.</span>
+                        <span class="metric__label">Points d’infrastructure</span>
+                        <strong class="metric__value"><?= number_format($empire['buildingPoints'] ?? 0) ?></strong>
+                        <span class="metric__hint">Total des niveaux de bâtiments développés.</span>
+                    </div>
+                    <div class="metric">
+                        <span class="metric__label">Points scientifiques</span>
+                        <strong class="metric__value"><?= number_format($empire['sciencePoints'] ?? 0) ?></strong>
+                        <span class="metric__hint">Somme des niveaux de recherches actives.</span>
                     </div>
                     <div class="metric">
                         <span class="metric__label">Puissance militaire</span>
-                        <strong class="metric__value"><?= number_format($empire['militaryPower'] ?? 0) ?></strong>
-                        <span class="metric__hint">Indice basé sur l’armement et la défense de votre flotte.</span>
+                        <strong class="metric__value"><?= number_format($empire['militaryPoints'] ?? ($empire['militaryPower'] ?? 0)) ?></strong>
+                        <span class="metric__hint">Valeur combinée d’attaque et de défense de la flotte.</span>
                     </div>
                 </div>
             </article>
             <article class="panel">
                 <header class="panel__header">
                     <h2>Production en cours</h2>
-                    <p class="panel__subtitle">Suivi des files de construction et de chantier spatial.</p>
+                    <p class="panel__subtitle">Bâtiments, recherches et chantiers spatiaux alignés.</p>
                 </header>
                 <div class="panel__body production-grid">
                     <div class="production-card">
@@ -165,7 +173,7 @@ ob_start();
             <article class="panel planet-summary">
                 <header class="panel__header">
                     <h2>Planète sélectionnée</h2>
-                    <p class="panel__subtitle">Ressources et état énergétique.</p>
+                    <p class="panel__subtitle">Ressources stockées et rythme de production.</p>
                 </header>
                 <div class="panel__body planet-summary__body">
                     <div class="planet-summary__preview"></div>

--- a/templates/pages/tech-tree/index.php
+++ b/templates/pages/tech-tree/index.php
@@ -36,7 +36,8 @@ foreach ($categories as $category) {
         }
     }
 }
-$nodesJson = htmlspecialchars(json_encode($nodes, JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
+$nodesJson = json_encode($nodes, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+$nodesJson = $nodesJson !== false ? $nodesJson : '{}';
 ob_start();
 ?>
 <section class="page-header">

--- a/templates/pages/tech-tree/index.php
+++ b/templates/pages/tech-tree/index.php
@@ -7,9 +7,28 @@ $title = $title ?? 'Arbre technologique';
 $categories = $tree['categories'] ?? [];
 $nodes = [];
 $initialNodeId = null;
+if (!function_exists('getTechState')) {
+    function getTechState(array $requirements): array
+    {
+        $total = count($requirements);
+        $met = 0;
+        foreach ($requirements as $requirement) {
+            if (!empty($requirement['met'])) {
+                ++$met;
+            }
+        }
+
+        return [
+            'met' => $met,
+            'total' => $total,
+            'allMet' => $total === 0 ? true : ($met === $total),
+        ];
+    }
+}
 foreach ($categories as $category) {
     foreach ($category['items'] as $item) {
         $nodeId = $category['key'] . ':' . $item['key'];
+        $item['state'] = getTechState($item['requires'] ?? []);
         $item['category'] = $category['label'];
         $nodes[$nodeId] = $item;
         if ($initialNodeId === null) {
@@ -58,8 +77,9 @@ ob_start();
                         <ul class="tech-section__list">
                             <?php foreach ($category['items'] as $item): ?>
                                 <?php $nodeId = $category['key'] . ':' . $item['key']; ?>
+                                <?php $state = getTechState($item['requires'] ?? []); ?>
                                 <li>
-                                    <button class="tech-node-link" type="button" data-tech-target="<?= htmlspecialchars($nodeId) ?>">
+                                    <button class="tech-node-link<?= $state['allMet'] ? ' tech-node-link--ready' : '' ?>" type="button" data-tech-target="<?= htmlspecialchars($nodeId) ?>" data-tech-ready="<?= $state['allMet'] ? '1' : '0' ?>">
                                         <span class="tech-node-link__label"><?= htmlspecialchars($item['label']) ?></span>
                                         <?php if (isset($item['level'])): ?>
                                             <span class="tech-node-link__level">Niveau <?= number_format((int) $item['level']) ?></span>

--- a/templates/research/index.php
+++ b/templates/research/index.php
@@ -103,26 +103,27 @@ ob_start();
         'title' => 'Recherches en cours',
         'subtitle' => 'Suivi des programmes scientifiques actifs',
         'body' => static function () use ($queue): void {
+            $emptyMessage = 'Aucune recherche n’est en cours. Lancez une étude pour étendre vos connaissances.';
+            echo '<div class="queue-block" data-queue="research" data-empty="' . htmlspecialchars($emptyMessage, ENT_QUOTES) . '">';
             if (($queue['count'] ?? 0) === 0) {
-                echo '<p class="empty-state">Aucune recherche n’est en cours. Lancez une étude pour étendre vos connaissances.</p>';
-
-                return;
-            }
-
-            echo '<ul class="queue-list">';
-            foreach ($queue['jobs'] as $job) {
-                $label = $job['label'] ?? $job['research'] ?? '';
-                echo '<li class="queue-list__item">';
-                echo '<div><strong>' . htmlspecialchars((string) $label) . '</strong><span>Niveau ' . number_format((int) ($job['targetLevel'] ?? 0)) . '</span></div>';
-                echo '<div class="queue-list__timing">';
-                echo '<span>Termine dans ' . htmlspecialchars(format_duration((int) ($job['remaining'] ?? 0))) . '</span>';
-                if (!empty($job['endsAt']) && $job['endsAt'] instanceof \DateTimeImmutable) {
-                    echo '<time datetime="' . $job['endsAt']->format('c') . '">' . $job['endsAt']->format('d/m H:i') . '</time>';
+                echo '<p class="empty-state">' . htmlspecialchars($emptyMessage) . '</p>';
+            } else {
+                echo '<ul class="queue-list">';
+                foreach ($queue['jobs'] as $job) {
+                    $label = $job['label'] ?? $job['research'] ?? '';
+                    echo '<li class="queue-list__item">';
+                    echo '<div><strong>' . htmlspecialchars((string) $label) . '</strong><span>Niveau ' . number_format((int) ($job['targetLevel'] ?? 0)) . '</span></div>';
+                    echo '<div class="queue-list__timing">';
+                    echo '<span>Termine dans ' . htmlspecialchars(format_duration((int) ($job['remaining'] ?? 0))) . '</span>';
+                    if (!empty($job['endsAt']) && $job['endsAt'] instanceof \DateTimeImmutable) {
+                        echo '<time datetime="' . $job['endsAt']->format('c') . '">' . $job['endsAt']->format('d/m H:i') . '</time>';
+                    }
+                    echo '</div>';
+                    echo '</li>';
                 }
-                echo '</div>';
-                echo '</li>';
+                echo '</ul>';
             }
-            echo '</ul>';
+            echo '</div>';
         },
     ]) ?>
 
@@ -184,7 +185,7 @@ ob_start();
                         }
                         echo '</div>';
                         echo '<footer class="research-entry__footer">';
-                        echo '<form method="post" action="' . htmlspecialchars($baseUrl) . '/research?planet=' . (int) $selectedPlanetId . '">';
+                        echo '<form method="post" action="' . htmlspecialchars($baseUrl) . '/research?planet=' . (int) $selectedPlanetId . '" data-async="queue" data-queue-target="research">';
                         echo '<input type="hidden" name="csrf_token" value="' . htmlspecialchars((string) $csrf_start) . '">';
                         echo '<input type="hidden" name="research" value="' . htmlspecialchars($definition->getKey()) . '">';
                         $label = $canResearch ? 'Lancer la recherche' : 'Pré-requis manquants';

--- a/templates/research/index.php
+++ b/templates/research/index.php
@@ -8,7 +8,6 @@
 
 $title = $title ?? 'Recherche';
 $icon = require __DIR__ . '/../components/_icon.php';
-$resourceBar = require __DIR__ . '/../components/_resource_bar.php';
 $card = require __DIR__ . '/../components/_card.php';
 
 if (!function_exists('format_duration')) {
@@ -31,18 +30,6 @@ if (!function_exists('format_duration')) {
         }
 
         return implode(' ', $parts);
-    }
-}
-
-$resourceSummaryData = [];
-if (is_array($activePlanetSummary)) {
-    $labels = ['metal' => 'Métal', 'crystal' => 'Cristal', 'hydrogen' => 'Hydrogène', 'energy' => 'Énergie'];
-    foreach ($activePlanetSummary['resources'] as $key => $data) {
-        $resourceSummaryData[$key] = [
-            'label' => $labels[$key] ?? ucfirst((string) $key),
-            'value' => $data['value'] ?? 0,
-            'perHour' => $data['perHour'] ?? 0,
-        ];
     }
 }
 
@@ -89,16 +76,6 @@ ob_start();
         },
     ]) ?>
 <?php else: ?>
-    <?php if ($resourceSummaryData !== []): ?>
-        <?= $card([
-            'title' => 'Ressources disponibles',
-            'subtitle' => 'Budget scientifique actuel',
-            'body' => static function () use ($resourceBar, $resourceSummaryData, $baseUrl): void {
-                echo $resourceBar($resourceSummaryData, ['baseUrl' => $baseUrl]);
-            },
-        ]) ?>
-    <?php endif; ?>
-
     <?= $card([
         'title' => 'Recherches en cours',
         'subtitle' => 'Suivi des programmes scientifiques actifs',

--- a/templates/shipyard/index.php
+++ b/templates/shipyard/index.php
@@ -8,7 +8,6 @@
 
 $title = $title ?? 'Chantier spatial';
 $icon = require __DIR__ . '/../components/_icon.php';
-$resourceBar = require __DIR__ . '/../components/_resource_bar.php';
 $card = require __DIR__ . '/../components/_card.php';
 
 if (!function_exists('format_duration')) {
@@ -31,18 +30,6 @@ if (!function_exists('format_duration')) {
         }
 
         return implode(' ', $parts);
-    }
-}
-
-$resourceSummaryData = [];
-if (is_array($activePlanetSummary)) {
-    $labels = ['metal' => 'Métal', 'crystal' => 'Cristal', 'hydrogen' => 'Hydrogène', 'energy' => 'Énergie'];
-    foreach ($activePlanetSummary['resources'] as $key => $data) {
-        $resourceSummaryData[$key] = [
-            'label' => $labels[$key] ?? ucfirst((string) $key),
-            'value' => $data['value'] ?? 0,
-            'perHour' => $data['perHour'] ?? 0,
-        ];
     }
 }
 
@@ -99,16 +86,6 @@ ob_start();
         },
     ]) ?>
 <?php else: ?>
-    <?php if ($resourceSummaryData !== []): ?>
-        <?= $card([
-            'title' => 'Ressources disponibles',
-            'subtitle' => 'Budget de production actuel',
-            'body' => static function () use ($resourceBar, $resourceSummaryData, $baseUrl): void {
-                echo $resourceBar($resourceSummaryData, ['baseUrl' => $baseUrl]);
-            },
-        ]) ?>
-    <?php endif; ?>
-
     <?= $card([
         'title' => 'Commandes de vaisseaux',
         'subtitle' => 'Suivi des constructions orbitales',

--- a/templates/shipyard/index.php
+++ b/templates/shipyard/index.php
@@ -113,26 +113,27 @@ ob_start();
         'title' => 'Commandes de vaisseaux',
         'subtitle' => 'Suivi des constructions orbitales',
         'body' => static function () use ($queue): void {
+            $emptyMessage = 'Aucune commande de vaisseau n’est en file. Lancez une production pour étoffer votre flotte.';
+            echo '<div class="queue-block" data-queue="shipyard" data-empty="' . htmlspecialchars($emptyMessage, ENT_QUOTES) . '">';
             if (($queue['count'] ?? 0) === 0) {
-                echo '<p class="empty-state">Aucune commande de vaisseau n’est en file. Lancez une production pour étoffer votre flotte.</p>';
-
-                return;
-            }
-
-            echo '<ul class="queue-list">';
-            foreach ($queue['jobs'] as $job) {
-                $label = $job['label'] ?? $job['ship'] ?? '';
-                echo '<li class="queue-list__item">';
-                echo '<div><strong>' . htmlspecialchars((string) $label) . '</strong><span>' . number_format((int) ($job['quantity'] ?? 0)) . ' unité(s)</span></div>';
-                echo '<div class="queue-list__timing">';
-                echo '<span>Termine dans ' . htmlspecialchars(format_duration((int) ($job['remaining'] ?? 0))) . '</span>';
-                if (!empty($job['endsAt']) && $job['endsAt'] instanceof \DateTimeImmutable) {
-                    echo '<time datetime="' . $job['endsAt']->format('c') . '">' . $job['endsAt']->format('d/m H:i') . '</time>';
+                echo '<p class="empty-state">' . htmlspecialchars($emptyMessage) . '</p>';
+            } else {
+                echo '<ul class="queue-list">';
+                foreach ($queue['jobs'] as $job) {
+                    $label = $job['label'] ?? $job['ship'] ?? '';
+                    echo '<li class="queue-list__item">';
+                    echo '<div><strong>' . htmlspecialchars((string) $label) . '</strong><span>' . number_format((int) ($job['quantity'] ?? 0)) . ' unité(s)</span></div>';
+                    echo '<div class="queue-list__timing">';
+                    echo '<span>Termine dans ' . htmlspecialchars(format_duration((int) ($job['remaining'] ?? 0))) . '</span>';
+                    if (!empty($job['endsAt']) && $job['endsAt'] instanceof \DateTimeImmutable) {
+                        echo '<time datetime="' . $job['endsAt']->format('c') . '">' . $job['endsAt']->format('d/m H:i') . '</time>';
+                    }
+                    echo '</div>';
+                    echo '</li>';
                 }
-                echo '</div>';
-                echo '</li>';
+                echo '</ul>';
             }
-            echo '</ul>';
+            echo '</div>';
         },
     ]) ?>
 
@@ -210,7 +211,7 @@ ob_start();
                         }
                         echo '</div>';
                         echo '<footer class="ship-card__footer">';
-                        echo '<form method="post" action="' . htmlspecialchars($baseUrl) . '/shipyard?planet=' . (int) $selectedPlanetId . '">';
+                        echo '<form method="post" action="' . htmlspecialchars($baseUrl) . '/shipyard?planet=' . (int) $selectedPlanetId . '" data-async="queue" data-queue-target="shipyard">';
                         echo '<input type="hidden" name="csrf_token" value="' . htmlspecialchars((string) $csrf_shipyard) . '">';
                         echo '<input type="hidden" name="ship" value="' . htmlspecialchars($definition->getKey()) . '">';
                         echo '<label class="ship-card__quantity"><span>Quantité</span><input type="number" name="quantity" min="1" value="1"' . ($canBuild ? '' : ' disabled') . '></label>';

--- a/tests/Application/UseCase/Auth/RegisterUserTest.php
+++ b/tests/Application/UseCase/Auth/RegisterUserTest.php
@@ -10,6 +10,7 @@ use App\Domain\Entity\User;
 use App\Domain\Repository\PlanetRepositoryInterface;
 use App\Domain\Repository\UserRepositoryInterface;
 use App\Infrastructure\Http\Session\Session;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 class RegisterUserTest extends TestCase
@@ -116,6 +117,9 @@ class InMemoryPlanetRepository implements PlanetRepositoryInterface
         $planet = new Planet(
             $this->autoIncrement++,
             $userId,
+            1,
+            1,
+            1,
             'Planète mère',
             1000,
             1000,
@@ -124,7 +128,12 @@ class InMemoryPlanetRepository implements PlanetRepositoryInterface
             0,
             0,
             0,
-            0
+            0,
+            80000,
+            60000,
+            40000,
+            1000,
+            new DateTimeImmutable()
         );
         $this->planets[$planet->getId()] = $planet;
 

--- a/tests/Application/UseCase/Dashboard/GetDashboardTest.php
+++ b/tests/Application/UseCase/Dashboard/GetDashboardTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\UseCase\Dashboard;
+
+use App\Application\Service\ProcessBuildQueue;
+use App\Application\Service\ProcessResearchQueue;
+use App\Application\Service\ProcessShipBuildQueue;
+use App\Application\UseCase\Dashboard\GetDashboard;
+use App\Domain\Repository\BuildingStateRepositoryInterface;
+use App\Domain\Repository\BuildQueueRepositoryInterface;
+use App\Domain\Repository\FleetRepositoryInterface;
+use App\Domain\Repository\PlanetRepositoryInterface;
+use App\Domain\Repository\PlayerStatsRepositoryInterface;
+use App\Domain\Repository\ResearchQueueRepositoryInterface;
+use App\Domain\Repository\ResearchStateRepositoryInterface;
+use App\Domain\Repository\ShipBuildQueueRepositoryInterface;
+use App\Domain\Service\BuildingCalculator;
+use App\Domain\Service\BuildingCatalog;
+use App\Domain\Service\ResearchCatalog;
+use App\Domain\Service\ShipCatalog;
+use PHPUnit\Framework\TestCase;
+
+class GetDashboardTest extends TestCase
+{
+    public function testSciencePowerDerivesFromScienceSpending(): void
+    {
+        $planetRepository = $this->createMock(PlanetRepositoryInterface::class);
+        $planetRepository->expects(self::once())
+            ->method('findByUser')
+            ->with(123)
+            ->willReturn([]);
+
+        $buildingStates = $this->createMock(BuildingStateRepositoryInterface::class);
+        $buildQueue = $this->createMock(BuildQueueRepositoryInterface::class);
+        $researchQueue = $this->createMock(ResearchQueueRepositoryInterface::class);
+        $shipQueue = $this->createMock(ShipBuildQueueRepositoryInterface::class);
+        $researchStates = $this->createMock(ResearchStateRepositoryInterface::class);
+        $fleetRepository = $this->createMock(FleetRepositoryInterface::class);
+
+        $playerStats = $this->createMock(PlayerStatsRepositoryInterface::class);
+        $playerStats->expects(self::once())
+            ->method('getScienceSpending')
+            ->with(123)
+            ->willReturn(4200);
+
+        $processBuildQueue = $this->createMock(ProcessBuildQueue::class);
+        $processBuildQueue->expects(self::never())->method('process');
+
+        $processResearchQueue = $this->createMock(ProcessResearchQueue::class);
+        $processResearchQueue->expects(self::never())->method('process');
+
+        $processShipQueue = $this->createMock(ProcessShipBuildQueue::class);
+        $processShipQueue->expects(self::never())->method('process');
+
+        $useCase = new GetDashboard(
+            $planetRepository,
+            $buildingStates,
+            $buildQueue,
+            $researchQueue,
+            $shipQueue,
+            $playerStats,
+            $researchStates,
+            $fleetRepository,
+            new BuildingCatalog([]),
+            new ResearchCatalog([]),
+            new ShipCatalog([]),
+            new BuildingCalculator(),
+            $processBuildQueue,
+            $processResearchQueue,
+            $processShipQueue
+        );
+
+        $result = $useCase->execute(123);
+
+        self::assertSame(4200, $result['empire']['scienceSpent']);
+        self::assertSame(4, $result['empire']['sciencePower']);
+        self::assertSame(0, $result['empire']['planetCount']);
+    }
+}

--- a/tools/db/create-database.php
+++ b/tools/db/create-database.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use DateTimeImmutable;
+use PDO;
+use RuntimeException;
+use Dotenv\Dotenv;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$projectRoot = dirname(__DIR__, 1);
+$envPath = dirname(__DIR__, 2);
+
+if (is_file($envPath . '/.env')) {
+    Dotenv::createImmutable($envPath)->safeLoad();
+}
+
+$parameters = require $envPath . '/config/parameters.php';
+
+$host = (string) ($parameters['db.host'] ?? '127.0.0.1');
+$port = (int) ($parameters['db.port'] ?? 3306);
+$dbName = (string) ($parameters['db.name'] ?? 'genesis_reborn');
+$user = (string) ($parameters['db.user'] ?? 'root');
+$password = $parameters['db.pass'] ?? null;
+
+$dsn = sprintf('mysql:host=%s;port=%d;charset=utf8mb4', $host, $port);
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+];
+
+if (defined('PDO::MYSQL_ATTR_MULTI_STATEMENTS')) {
+    $options[PDO::MYSQL_ATTR_MULTI_STATEMENTS] = true;
+}
+
+$pdo = new PDO($dsn, $user, $password, $options);
+
+$pdo->exec(sprintf(
+    'CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
+    str_replace('`', '``', $dbName)
+));
+$pdo->exec(sprintf('USE `%s`', str_replace('`', '``', $dbName)));
+
+echo sprintf("Database '%s' selected.%s", $dbName, PHP_EOL);
+
+$migrationDir = $envPath . '/migrations';
+$files = glob($migrationDir . '/*.sql');
+if ($files === false) {
+    throw new RuntimeException('Unable to read migrations directory.');
+}
+
+sort($files);
+
+foreach ($files as $file) {
+    $sql = file_get_contents($file);
+    if ($sql === false) {
+        throw new RuntimeException(sprintf('Cannot read migration file: %s', $file));
+    }
+
+    $pdo->exec($sql);
+    echo sprintf('[%s] %s applied.%s', (new DateTimeImmutable())->format('H:i:s'), basename($file), PHP_EOL);
+}
+
+echo 'Database is ready.' . PHP_EOL;


### PR DESCRIPTION
## Changelog
- enforce sequential queueing rules and level targeting for buildings, research and shipyard, including queue size guards
- track cumulative science spending to feed the new dashboard science power metric and player stats repository
- add JSON endpoints and async UI updates for queues, resource header refreshes and tech tree prerequisite styling

## Tests
- [x] composer test
- [x] composer stan
- [x] composer cs

------
https://chatgpt.com/codex/tasks/task_e_68cd07f2049483329de584e686d22f5d