### PR TITLE
Use shared format_duration helper across templates

### DIFF
--- a/templates/colony/index.php
+++ b/templates/colony/index.php
@@ -13,29 +13,7 @@ $buildings = $overview['buildings'] ?? [];
 
 $icon = require __DIR__ . '/../components/_icon.php';
 $card = require __DIR__ . '/../components/_card.php';
-
-if (!function_exists('format_duration')) {
-    function format_duration(int $seconds): string
-    {
-        $seconds = max(0, $seconds);
-        $hours = intdiv($seconds, 3600);
-        $minutes = intdiv($seconds % 3600, 60);
-        $remainingSeconds = $seconds % 60;
-
-        $parts = [];
-        if ($hours > 0) {
-            $parts[] = sprintf('%d h', $hours);
-        }
-        if ($minutes > 0) {
-            $parts[] = sprintf('%d min', $minutes);
-        }
-        if (($hours === 0 && $minutes === 0) || $remainingSeconds > 0) {
-            $parts[] = sprintf('%d s', $remainingSeconds);
-        }
-
-        return implode(' ', $parts);
-    }
-}
+require_once __DIR__ . '/../components/helpers.php';
 
 $resourceLabels = [
     'metal' => 'Métal',

--- a/templates/components/helpers.php
+++ b/templates/components/helpers.php
@@ -1,0 +1,24 @@
+<?php
+
+if (!function_exists('format_duration')) {
+    function format_duration(int $seconds): string
+    {
+        $seconds = max(0, $seconds);
+        $hours = intdiv($seconds, 3600);
+        $minutes = intdiv($seconds % 3600, 60);
+        $remainingSeconds = $seconds % 60;
+
+        $parts = [];
+        if ($hours > 0) {
+            $parts[] = sprintf('%d h', $hours);
+        }
+        if ($minutes > 0) {
+            $parts[] = sprintf('%d min', $minutes);
+        }
+        if (($hours === 0 && $minutes === 0) || $remainingSeconds > 0) {
+            $parts[] = sprintf('%d s', $remainingSeconds);
+        }
+
+        return implode(' ', $parts);
+    }
+}

--- a/templates/fleet/index.php
+++ b/templates/fleet/index.php
@@ -15,29 +15,7 @@
 $title = $title ?? 'Flotte';
 $icon = require __DIR__ . '/../components/_icon.php';
 $card = require __DIR__ . '/../components/_card.php';
-
-if (!function_exists('format_duration')) {
-    function format_duration(int $seconds): string
-    {
-        $seconds = max(0, $seconds);
-        $hours = intdiv($seconds, 3600);
-        $minutes = intdiv($seconds % 3600, 60);
-        $remainingSeconds = $seconds % 60;
-
-        $parts = [];
-        if ($hours > 0) {
-            $parts[] = sprintf('%d h', $hours);
-        }
-        if ($minutes > 0) {
-            $parts[] = sprintf('%d min', $minutes);
-        }
-        if (($hours === 0 && $minutes === 0) || $remainingSeconds > 0) {
-            $parts[] = sprintf('%d s', $remainingSeconds);
-        }
-
-        return implode(' ', $parts);
-    }
-}
+require_once __DIR__ . '/../components/helpers.php';
 
 $fleetShips = $fleetOverview['ships'] ?? [];
 $totalShips = $fleetOverview['totalShips'] ?? 0;

--- a/templates/pages/dashboard/index.php
+++ b/templates/pages/dashboard/index.php
@@ -8,28 +8,7 @@
 /** @var int|null $selectedPlanetId */
 /** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
 $title = $title ?? 'Vue d’ensemble';
-if (!function_exists('format_duration')) {
-    function format_duration(int $seconds): string
-    {
-        $seconds = max(0, $seconds);
-        $hours = intdiv($seconds, 3600);
-        $minutes = intdiv($seconds % 3600, 60);
-        $remainingSeconds = $seconds % 60;
-
-        $parts = [];
-        if ($hours > 0) {
-            $parts[] = sprintf('%d h', $hours);
-        }
-        if ($minutes > 0) {
-            $parts[] = sprintf('%d min', $minutes);
-        }
-        if (($hours === 0 && $minutes === 0) || $remainingSeconds > 0) {
-            $parts[] = sprintf('%d s', $remainingSeconds);
-        }
-
-        return implode(' ', $parts);
-    }
-}
+require_once __DIR__ . '/../../components/helpers.php';
 
 $empire = $dashboard['empire'] ?? [
     'points' => 0,

--- a/templates/profile/index.php
+++ b/templates/profile/index.php
@@ -9,30 +9,8 @@ $title = $title ?? 'Profil commandant';
 $icon = require __DIR__ . '/../components/_icon.php';
 $resourceBar = require __DIR__ . '/../components/_resource_bar.php';
 $card = require __DIR__ . '/../components/_card.php';
+require_once __DIR__ . '/../components/helpers.php';
 $planets = $planets ?? [];
-
-if (!function_exists('format_duration')) {
-    function format_duration(int $seconds): string
-    {
-        $seconds = max(0, $seconds);
-        $hours = intdiv($seconds, 3600);
-        $minutes = intdiv($seconds % 3600, 60);
-        $remainingSeconds = $seconds % 60;
-
-        $parts = [];
-        if ($hours > 0) {
-            $parts[] = sprintf('%d h', $hours);
-        }
-        if ($minutes > 0) {
-            $parts[] = sprintf('%d min', $minutes);
-        }
-        if (($hours === 0 && $minutes === 0) || $remainingSeconds > 0) {
-            $parts[] = sprintf('%d s', $remainingSeconds);
-        }
-
-        return implode(' ', $parts);
-    }
-}
 
 $dashboard = $dashboard ?? [];
 $empire = $dashboard['empire'] ?? ['points' => 0, 'militaryPower' => 0, 'planetCount' => count($planets)];

--- a/templates/research/index.php
+++ b/templates/research/index.php
@@ -9,29 +9,7 @@
 $title = $title ?? 'Laboratoire de recherche';
 $icon = require __DIR__ . '/../components/_icon.php';
 $card = require __DIR__ . '/../components/_card.php';
-
-if (!function_exists('format_duration')) {
-    function format_duration(int $seconds): string
-    {
-        $seconds = max(0, $seconds);
-        $hours = intdiv($seconds, 3600);
-        $minutes = intdiv($seconds % 3600, 60);
-        $remainingSeconds = $seconds % 60;
-
-        $parts = [];
-        if ($hours > 0) {
-            $parts[] = sprintf('%d h', $hours);
-        }
-        if ($minutes > 0) {
-            $parts[] = sprintf('%d min', $minutes);
-        }
-        if (($hours === 0 && $minutes === 0) || $remainingSeconds > 0) {
-            $parts[] = sprintf('%d s', $remainingSeconds);
-        }
-
-        return implode(' ', $parts);
-    }
-}
+require_once __DIR__ . '/../components/helpers.php';
 
 $overview = $overview ?? null;
 $queue = $overview['queue'] ?? ['count' => 0, 'jobs' => []];

--- a/templates/shipyard/index.php
+++ b/templates/shipyard/index.php
@@ -9,29 +9,7 @@
 $title = $title ?? 'Chantier spatial';
 $icon = require __DIR__ . '/../components/_icon.php';
 $card = require __DIR__ . '/../components/_card.php';
-
-if (!function_exists('format_duration')) {
-    function format_duration(int $seconds): string
-    {
-        $seconds = max(0, $seconds);
-        $hours = intdiv($seconds, 3600);
-        $minutes = intdiv($seconds % 3600, 60);
-        $remainingSeconds = $seconds % 60;
-
-        $parts = [];
-        if ($hours > 0) {
-            $parts[] = sprintf('%d h', $hours);
-        }
-        if ($minutes > 0) {
-            $parts[] = sprintf('%d min', $minutes);
-        }
-        if (($hours === 0 && $minutes === 0) || $remainingSeconds > 0) {
-            $parts[] = sprintf('%d s', $remainingSeconds);
-        }
-
-        return implode(' ', $parts);
-    }
-}
+require_once __DIR__ . '/../components/helpers.php';
 
 $overview = $overview ?? null;
 $queue = $overview['queue'] ?? ['count' => 0, 'jobs' => []];


### PR DESCRIPTION
## Summary
- add a reusable `format_duration` helper in `templates/components`
- update colony, shipyard, research, fleet, profile, and dashboard views to include the shared helper instead of local copies

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0dd2a5e08332bfde3d17994b731c