### PR TITLE
Remove unused project root reference from DB script

### DIFF
--- a/tools/db/create-database.php
+++ b/tools/db/create-database.php
@@ -9,7 +9,6 @@ use Dotenv\Dotenv;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$projectRoot = dirname(__DIR__, 1);
 $envPath = dirname(__DIR__, 2);
 
 if (is_file($envPath . '/.env')) {


### PR DESCRIPTION
## Summary
- remove the unused $projectRoot variable from tools/db/create-database.php

## Testing
- php tools/db/create-database.php

------
https://chatgpt.com/codex/tasks/task_e_68cf0dd92c8c8332a587e819c0c839a7