### PR TITLE
Add configurable research lab speed bonus

### DIFF
--- a/config/game/buildings.php
+++ b/config/game/buildings.php
@@ -148,6 +148,7 @@ return [
             ],
             'research' => [],
         ],
+        'research_speed_bonus' => 0.1,
     ],
     'shipyard' => [
         'label' => 'Chantier spatial Asterion',

--- a/config/services.php
+++ b/config/services.php
@@ -104,7 +104,12 @@ return function (Container $container): void {
         return new ResearchCatalog($config);
     });
 
-    $container->set(ResearchCalculator::class, fn () => new ResearchCalculator());
+    $container->set(ResearchCalculator::class, function () {
+        $config = require __DIR__ . '/game/buildings.php';
+        $bonus = (float) ($config['research_lab']['research_speed_bonus'] ?? 0.0);
+
+        return new ResearchCalculator($bonus);
+    });
 
     $container->set(ShipCatalog::class, function () {
         $config = require __DIR__ . '/game/ships.php';

--- a/src/Application/UseCase/Research/GetResearchOverview.php
+++ b/src/Application/UseCase/Research/GetResearchOverview.php
@@ -81,7 +81,7 @@ class GetResearchOverview
                 $effectiveResearchLevels = $researchLevels;
                 $effectiveResearchLevels[$definition->getKey()] = $effectiveLevel;
                 $nextCost = $this->calculator->nextCost($definition, $effectiveLevel);
-                $nextTime = $this->calculator->nextTime($definition, $effectiveLevel);
+                $nextTime = $this->calculator->nextTime($definition, $effectiveLevel, $labLevel);
                 $requirements = $this->calculator->checkRequirements(
                     $definition,
                     $effectiveResearchLevels,

--- a/src/Application/UseCase/Research/StartResearch.php
+++ b/src/Application/UseCase/Research/StartResearch.php
@@ -74,7 +74,7 @@ class StartResearch
         }
 
         $this->deductCost($planet, $cost);
-        $duration = $this->calculator->nextTime($definition, $targetLevel - 1);
+        $duration = $this->calculator->nextTime($definition, $targetLevel - 1, $labLevel);
         $this->researchQueue->enqueue($planetId, $researchKey, $targetLevel, $duration);
         $this->playerStats->addScienceSpending($userId, $this->sumCost($cost));
         $this->planets->update($planet);

--- a/src/Domain/Entity/BuildingDefinition.php
+++ b/src/Domain/Entity/BuildingDefinition.php
@@ -24,7 +24,8 @@ class BuildingDefinition
         private readonly array $requirements = [],
         private readonly ?string $image = null,
         private readonly array $storage = [],
-        private readonly array $upkeep = []
+        private readonly array $upkeep = [],
+        private readonly float $researchSpeedBonus = 0.0
     ) {
     }
 
@@ -114,5 +115,10 @@ class BuildingDefinition
     public function getUpkeepConfig(): array
     {
         return $this->upkeep;
+    }
+
+    public function getResearchSpeedBonus(): float
+    {
+        return $this->researchSpeedBonus;
     }
 }

--- a/src/Domain/Service/BuildingCatalog.php
+++ b/src/Domain/Service/BuildingCatalog.php
@@ -32,7 +32,8 @@ class BuildingCatalog
                 $data['requires'] ?? [],
                 $data['image'] ?? null,
                 $data['storage'] ?? [],
-                $data['upkeep'] ?? []
+                $data['upkeep'] ?? [],
+                (float) ($data['research_speed_bonus'] ?? 0.0)
             );
         }
     }

--- a/src/Domain/Service/ResearchCalculator.php
+++ b/src/Domain/Service/ResearchCalculator.php
@@ -6,6 +6,10 @@ use App\Domain\Entity\ResearchDefinition;
 
 class ResearchCalculator
 {
+    public function __construct(private readonly float $labSpeedBonusPerLevel = 0.0)
+    {
+    }
+
     /**
      * @return array<string, int>
      */
@@ -19,9 +23,18 @@ class ResearchCalculator
         return $costs;
     }
 
-    public function nextTime(ResearchDefinition $definition, int $currentLevel): int
+    public function nextTime(ResearchDefinition $definition, int $currentLevel, int $labLevel): int
     {
-        return (int) round($definition->getBaseTime() * pow($definition->getGrowthTime(), $currentLevel));
+        $baseDuration = (float) $definition->getBaseTime() * pow($definition->getGrowthTime(), $currentLevel);
+        $effectiveLabLevel = max(0, $labLevel);
+        $bonusPerLevel = max(0.0, $this->labSpeedBonusPerLevel);
+        $speedMultiplier = 1.0 + ($effectiveLabLevel * $bonusPerLevel);
+
+        if ($speedMultiplier > 0.0) {
+            $baseDuration /= $speedMultiplier;
+        }
+
+        return max(1, (int) round($baseDuration));
     }
 
     /**

--- a/tests/Unit/ResearchCalculatorTest.php
+++ b/tests/Unit/ResearchCalculatorTest.php
@@ -16,7 +16,7 @@ class ResearchCalculatorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->calculator = new ResearchCalculator();
+        $this->calculator = new ResearchCalculator(0.1);
         $this->definition = new ResearchDefinition(
             'hyperdrive',
             'Propulsion hyperspatial',
@@ -92,10 +92,23 @@ class ResearchCalculatorTest extends TestCase
         self::assertGreaterThan($level0Cost['crystal'], $level2Cost['crystal']);
         self::assertGreaterThan($level0Cost['hydrogen'], $level2Cost['hydrogen']);
 
-        $baseTime = $this->calculator->nextTime($this->definition, 0);
-        $levelThreeTime = $this->calculator->nextTime($this->definition, 3);
+        $baseTime = $this->calculator->nextTime($this->definition, 0, 0);
+        $levelThreeTime = $this->calculator->nextTime($this->definition, 3, 0);
 
         self::assertSame(120, $baseTime);
         self::assertGreaterThan($baseTime, $levelThreeTime);
+    }
+
+    public function testNextTimeAppliesLabBonusAndRespectsMinimum(): void
+    {
+        $noLab = $this->calculator->nextTime($this->definition, 0, 0);
+        $withLab = $this->calculator->nextTime($this->definition, 0, 5);
+
+        self::assertLessThan($noLab, $withLab);
+
+        $aggressiveCalculator = new ResearchCalculator(0.5);
+        $shortDuration = $aggressiveCalculator->nextTime($this->definition, 0, 1000);
+
+        self::assertSame(1, $shortDuration);
     }
 }


### PR DESCRIPTION
## Summary
- add a configurable `research_speed_bonus` to the research lab and expose it through the building catalog
- adjust the research time calculation to account for laboratory level bonuses with a one-second minimum
- update research workflows and tests to cover the new timing behaviour

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cf132ab4548332a18b143a3b9aae7b