### PR TITLE
Display resource capacities in the HUD

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,11 @@ tests (PHPUnit)
 - **Sprite d’icônes** (`public/assets/svg/sprite.svg`) via `<use href="/assets/svg/sprite.svg#icon-...">`.
 - **Pipeline icônes** : ajouter des SVG dans `public/assets/svg/icons/` puis exécuter `npm run svgo:build`.
 
+### Comportement du ticker de ressources
+- Le snapshot de ressources embarque désormais la capacité maximale pour chaque type, exposée dans le layout et via l’API.
+- Le ticker JavaScript conserve cette capacité, borne les valeurs à 0 et affiche l’information sous la forme `actuel / capacité`.
+- Lorsque la réserve atteint 0 avec un débit horaire négatif, le composant applique `resource-meter--warning` afin de signaler visuellement l’épuisement.
+
 ---
 
 ## Sessions & sécurité

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -478,6 +478,11 @@ main.workspace__content {
     font-size: 1.25rem;
 }
 
+.resource-meter__capacity {
+    font-size: var(--font-size-sm);
+    color: var(--color-muted);
+}
+
 .resource-meter__rate {
     font-size: var(--font-size-sm);
     color: var(--color-muted);
@@ -489,6 +494,21 @@ main.workspace__content {
 
 .resource-meter__rate.is-negative {
     color: var(--color-danger);
+}
+
+.resource-meter--warning {
+    background: var(--danger-soft);
+    border-color: var(--danger-border);
+}
+
+.resource-meter--warning .resource-meter__label,
+.resource-meter--warning .resource-meter__value,
+.resource-meter--warning .resource-meter__capacity {
+    color: var(--danger);
+}
+
+.resource-meter--warning .resource-meter__icon {
+    background: rgba(255, 122, 122, 0.16);
 }
 
 /* Buttons */

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -38,7 +38,7 @@ const resourceTicker = {
     intervalId: null,
 };
 
-const renderResourceMeter = (key, value, perHour) => {
+const renderResourceMeter = (key, value, perHour, capacity) => {
     const meter = document.querySelector(`.resource-meter[data-resource="${CSS.escape(key)}"]`);
     if (!meter) {
         return;
@@ -46,12 +46,29 @@ const renderResourceMeter = (key, value, perHour) => {
 
     const valueElement = meter.querySelector('[data-resource-value]');
     const rateElement = meter.querySelector('[data-resource-rate]');
-    const normalizedValue = Math.floor(Number.isFinite(value) ? value : 0);
-    const normalizedPerHour = Number.isFinite(perHour) ? perHour : 0;
+    const capacityElement = meter.querySelector('[data-resource-capacity-display]');
+    const numericCapacity = typeof capacity === 'number' ? capacity : Number(capacity ?? 0);
+    const normalizedCapacity = Math.max(0, Math.floor(Number.isFinite(numericCapacity) ? numericCapacity : 0));
+    const numericValue = typeof value === 'number' ? value : Number(value ?? 0);
+    const normalizedValue = Math.max(0, Math.floor(Number.isFinite(numericValue) ? numericValue : 0));
+    const cappedValue = normalizedCapacity > 0 ? Math.min(normalizedValue, normalizedCapacity) : normalizedValue;
+    const numericPerHour = typeof perHour === 'number' ? perHour : Number(perHour ?? 0);
+    const normalizedPerHour = Number.isFinite(numericPerHour) ? numericPerHour : 0;
 
     if (valueElement) {
-        valueElement.textContent = formatNumber(normalizedValue);
+        valueElement.textContent = formatNumber(cappedValue);
     }
+
+    if (capacityElement) {
+        capacityElement.textContent = normalizedCapacity > 0
+            ? `/ ${formatNumber(normalizedCapacity)}`
+            : '/ —';
+    }
+
+    meter.dataset.resourceCapacity = String(normalizedCapacity);
+
+    const isDepleted = cappedValue <= 0 && normalizedPerHour < 0;
+    meter.classList.toggle('resource-meter--warning', isDepleted);
 
     if (rateElement) {
         const ratePrefix = key !== 'energy' && normalizedPerHour > 0 ? '+' : '';
@@ -83,10 +100,21 @@ const startResourceTicker = () => {
                 return;
             }
 
-            const increment = state.perHour * (elapsedSeconds / 3600);
-            state.value += increment;
+            const perHour = Number.isFinite(state.perHour) ? state.perHour : 0;
+            const capacity = Number.isFinite(state.capacity) ? Math.max(0, state.capacity) : 0;
+            const currentValue = Number.isFinite(state.value) ? state.value : 0;
+            const increment = perHour * (elapsedSeconds / 3600);
+            let nextValue = currentValue + increment;
+            nextValue = Math.max(0, nextValue);
+            if (capacity > 0) {
+                nextValue = Math.min(nextValue, capacity);
+            }
+
+            state.value = nextValue;
+            state.perHour = perHour;
+            state.capacity = capacity;
             state.timestamp = now;
-            renderResourceMeter(key, state.value, state.perHour);
+            renderResourceMeter(key, state.value, perHour, capacity);
         });
     }, 1000);
 };
@@ -97,16 +125,22 @@ const applyResourceSnapshot = (resources = {}) => {
 
     Object.entries(resources).forEach(([key, data]) => {
         const source = data && typeof data === 'object' ? data : {};
-        const value = Number(source.value ?? 0);
-        const perHour = Number(source.perHour ?? 0);
+        const numericValue = typeof source.value === 'number' ? source.value : Number(source.value ?? 0);
+        const numericPerHour = typeof source.perHour === 'number' ? source.perHour : Number(source.perHour ?? 0);
+        const numericCapacity = typeof source.capacity === 'number' ? source.capacity : Number(source.capacity ?? 0);
+        const normalizedCapacity = Math.max(0, Math.floor(Number.isFinite(numericCapacity) ? numericCapacity : 0));
+        const normalizedPerHour = Number.isFinite(numericPerHour) ? numericPerHour : 0;
+        const normalizedValue = Math.max(0, Number.isFinite(numericValue) ? numericValue : 0);
+        const cappedValue = normalizedCapacity > 0 ? Math.min(normalizedValue, normalizedCapacity) : normalizedValue;
 
         resourceTicker.states.set(key, {
-            value,
-            perHour,
+            value: cappedValue,
+            perHour: normalizedPerHour,
+            capacity: normalizedCapacity,
             timestamp: now,
         });
 
-        renderResourceMeter(key, value, perHour);
+        renderResourceMeter(key, cappedValue, normalizedPerHour, normalizedCapacity);
     });
 
     startResourceTicker();
@@ -129,10 +163,18 @@ const bootstrapResourceTicker = () => {
         const rateText = meter.querySelector('[data-resource-rate]')?.textContent ?? '0';
         const numericValue = Number(valueText.replace(/[^0-9-]/g, ''));
         const numericRate = Number(rateText.replace(/[^0-9-]/g, ''));
+        const capacityAttr = meter.dataset.resourceCapacity ?? meter.getAttribute('data-resource-capacity') ?? '0';
+        let numericCapacity = Number(capacityAttr);
+        if (!Number.isFinite(numericCapacity)) {
+            const capacityText = meter.querySelector('[data-resource-capacity-display]')?.textContent ?? '0';
+            const parsedCapacity = Number(capacityText.replace(/[^0-9-]/g, ''));
+            numericCapacity = Number.isFinite(parsedCapacity) ? parsedCapacity : 0;
+        }
 
         snapshot[key] = {
             value: Number.isFinite(numericValue) ? numericValue : 0,
             perHour: Number.isFinite(numericRate) ? numericRate : 0,
+            capacity: Number.isFinite(numericCapacity) ? numericCapacity : 0,
         };
     });
 

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -77,10 +77,26 @@ abstract class AbstractController
     protected function formatResourceSnapshot(Planet $planet): array
     {
         return [
-            'metal' => ['value' => $planet->getMetal(), 'perHour' => $planet->getMetalPerHour()],
-            'crystal' => ['value' => $planet->getCrystal(), 'perHour' => $planet->getCrystalPerHour()],
-            'hydrogen' => ['value' => $planet->getHydrogen(), 'perHour' => $planet->getHydrogenPerHour()],
-            'energy' => ['value' => $planet->getEnergy(), 'perHour' => $planet->getEnergyPerHour()],
+            'metal' => [
+                'value' => $planet->getMetal(),
+                'perHour' => $planet->getMetalPerHour(),
+                'capacity' => $planet->getMetalCapacity(),
+            ],
+            'crystal' => [
+                'value' => $planet->getCrystal(),
+                'perHour' => $planet->getCrystalPerHour(),
+                'capacity' => $planet->getCrystalCapacity(),
+            ],
+            'hydrogen' => [
+                'value' => $planet->getHydrogen(),
+                'perHour' => $planet->getHydrogenPerHour(),
+                'capacity' => $planet->getHydrogenCapacity(),
+            ],
+            'energy' => [
+                'value' => $planet->getEnergy(),
+                'perHour' => $planet->getEnergyPerHour(),
+                'capacity' => $planet->getEnergyCapacity(),
+            ],
         ];
     }
 }

--- a/src/Controller/ResourceApiController.php
+++ b/src/Controller/ResourceApiController.php
@@ -159,12 +159,7 @@ class ResourceApiController extends AbstractController
         return $this->json([
             'success' => true,
             'planetId' => $planetId,
-            'resources' => [
-                'metal' => ['value' => $planet->getMetal(), 'perHour' => $planet->getMetalPerHour()],
-                'crystal' => ['value' => $planet->getCrystal(), 'perHour' => $planet->getCrystalPerHour()],
-                'hydrogen' => ['value' => $planet->getHydrogen(), 'perHour' => $planet->getHydrogenPerHour()],
-                'energy' => ['value' => $planet->getEnergy(), 'perHour' => $planet->getEnergyPerHour()],
-            ],
+            'resources' => $this->formatResourceSnapshot($planet),
         ]);
     }
 }

--- a/templates/layouts/base.php
+++ b/templates/layouts/base.php
@@ -4,7 +4,7 @@
 /** @var array<int, array{type: string, message: string}> $flashes */
 /** @var int|null $currentUserId */
 /** @var string|null $csrf_logout */
-/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
+/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int, capacity: int}>}|null $activePlanetSummary */
 /** @var array<int, \App\Domain\Entity\Planet> $planets */
 /** @var string|null $activeSection */
 /** @var int|null $selectedPlanetId */
@@ -162,14 +162,18 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                 <div class="topbar__resources">
                     <?php foreach (['metal' => 'Métal', 'crystal' => 'Cristal', 'hydrogen' => 'Hydrogène', 'energy' => 'Énergie'] as $key => $label): ?>
                         <?php
-                        $data = $resourceSummary[$key] ?? ['value' => 0, 'perHour' => 0];
+                        $data = $resourceSummary[$key] ?? ['value' => 0, 'perHour' => 0, 'capacity' => 0];
+                        $value = max(0, (int) ($data['value'] ?? 0));
+                        $capacityValue = max(0, (int) ($data['capacity'] ?? 0));
                         $perHourValue = (int) ($data['perHour'] ?? 0);
                         $rateNumber = number_format($perHourValue);
                         $ratePrefix = ($key !== 'energy' && $perHourValue > 0) ? '+' : '';
                         $rateDisplay = $ratePrefix . $rateNumber . '/h';
                         $rateClass = $perHourValue >= 0 ? 'is-positive' : 'is-negative';
+                        $capacityDisplay = $capacityValue > 0 ? number_format($capacityValue) : '—';
+                        $meterClasses = 'resource-meter' . (($value <= 0 && $perHourValue < 0) ? ' resource-meter--warning' : '');
                         ?>
-                        <div class="resource-meter" role="group" aria-label="<?= htmlspecialchars($label) ?>" data-resource="<?= htmlspecialchars($key) ?>">
+                        <div class="<?= $meterClasses ?>" role="group" aria-label="<?= htmlspecialchars($label) ?>" data-resource="<?= htmlspecialchars($key) ?>" data-resource-capacity="<?= $capacityValue ?>">
                             <div class="resource-meter__icon">
                                 <svg class="icon icon-sm" aria-hidden="true">
                                     <use href="<?= htmlspecialchars($baseUrl) ?>/assets/svg/sprite.svg#icon-<?= htmlspecialchars($key) ?>"></use>
@@ -178,7 +182,8 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                             <div class="resource-meter__details">
                                 <span class="resource-meter__label"><?= htmlspecialchars($label) ?></span>
                                 <div class="resource-meter__values">
-                                    <span class="resource-meter__value" data-resource-value><?= number_format((int) ($data['value'] ?? 0)) ?></span>
+                                    <span class="resource-meter__value" data-resource-value><?= number_format($value) ?></span>
+                                    <span class="resource-meter__capacity" data-resource-capacity-display>/ <?= htmlspecialchars($capacityDisplay) ?></span>
                                     <span class="resource-meter__rate <?= $rateClass ?>" data-resource-rate><?= htmlspecialchars($rateDisplay) ?></span>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- extend resource snapshots and API responses to expose per-resource capacities
- update the top bar layout, ticker logic and styles to display capacity and warn when depleted
- document the new HUD behaviour in the frontend README

## Testing
- npm run lint
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cf132f7b708332b5822dc596ce629a