### PR TITLE
Add collapsible requirements panel component

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -768,27 +768,153 @@ main.workspace__content {
     gap: var(--space-2);
 }
 
-.building-card__requirements {
+.requirements-panel {
+    border: 1px solid var(--border-soft);
+    border-radius: var(--radius-sm);
+    background: var(--bg-soft);
+    transition: background var(--transition-base), border-color var(--transition-base), box-shadow var(--transition-base);
+    overflow: hidden;
+}
+
+.requirements-panel:hover {
+    border-color: var(--color-border);
+}
+
+.requirements-panel[open] {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    box-shadow: 0 0 0 1px rgba(108, 216, 255, 0.25);
+}
+
+.requirements-panel__summary {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3);
+    list-style: none;
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--text-primary);
+    transition: color var(--transition-base);
+    user-select: none;
+}
+
+.requirements-panel__summary::-webkit-details-marker {
+    display: none;
+}
+
+.requirements-panel__summary:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+    border-radius: inherit;
+}
+
+.requirements-panel__summary:hover {
+    color: var(--accent);
+}
+
+.requirements-panel[open] .requirements-panel__summary {
+    color: var(--accent);
+}
+
+.requirements-panel__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.requirements-panel__glyph {
+    color: inherit;
+}
+
+.requirements-panel__title {
+    flex: 1;
+}
+
+.requirements-panel__chevron {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    color: var(--color-muted);
+    transition: transform var(--transition-base), color var(--transition-base);
+}
+
+.requirements-panel__chevron::before {
+    content: '';
+    width: 0.5rem;
+    height: 0.5rem;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg);
+    display: block;
+}
+
+.requirements-panel[open] .requirements-panel__chevron {
+    transform: rotate(-135deg);
+    color: var(--accent);
+}
+
+.requirements-panel__content {
+    padding: 0 var(--space-3) var(--space-3);
+    border-top: 1px solid var(--border-soft);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.requirements-panel[open] .requirements-panel__content {
+    animation: requirements-panel-reveal var(--transition-base) ease;
+}
+
+.building-card__requirements,
+.requirements-panel__list {
     margin: 0;
-    padding-left: 1.25rem;
-    display: grid;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
     gap: var(--space-1);
 }
 
-.building-card__requirements li {
-    list-style: disc;
-    color: var(--text-primary);
+.requirements-panel__item {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    justify-content: space-between;
     font-size: var(--font-size-sm);
+    color: var(--text-primary);
 }
 
+.requirements-panel__name,
 .building-card__requirement-name {
     font-weight: 600;
 }
 
+.requirements-panel__name {
+    flex: 1;
+}
+
+.requirements-panel__progress,
 .building-card__requirement-progress {
     color: var(--color-muted);
-    margin-left: var(--space-1);
     font-variant-numeric: tabular-nums;
+}
+
+.requirements-panel__progress {
+    margin-left: var(--space-2);
+}
+
+@keyframes requirements-panel-reveal {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .status-pill {
@@ -1131,14 +1257,6 @@ main.workspace__content {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
-}
-
-.tech-card__requirements ul {
-    margin: 0;
-    padding-left: 1.2rem;
-    display: grid;
-    gap: var(--space-1);
-    color: var(--color-muted);
 }
 
 /* Metrics */

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -398,6 +398,52 @@ const initAutoSubmitSelects = () => {
     });
 };
 
+const initRequirementsPanels = () => {
+    const panels = document.querySelectorAll('[data-requirements-panel]');
+    if (panels.length === 0) {
+        return;
+    }
+
+    let autoId = 0;
+    const ensureId = (element, suffix = '') => {
+        if (element.id) {
+            return element.id;
+        }
+
+        autoId += 1;
+        const id = `requirements-panel-${autoId}${suffix}`;
+        element.id = id;
+
+        return id;
+    };
+
+    panels.forEach((panel) => {
+        const summary = panel.querySelector('[data-requirements-summary]');
+        const content = panel.querySelector('[data-requirements-content]');
+        if (!summary || !content) {
+            return;
+        }
+
+        const summaryId = ensureId(summary);
+        const contentId = content.id || `${summaryId}-content`;
+        if (!content.id) {
+            content.id = contentId;
+        }
+
+        summary.setAttribute('aria-controls', content.id);
+        content.setAttribute('aria-labelledby', summaryId);
+
+        const syncState = () => {
+            const isOpen = panel.hasAttribute('open');
+            summary.setAttribute('aria-expanded', String(isOpen));
+            content.setAttribute('aria-hidden', String(!isOpen));
+        };
+
+        syncState();
+        panel.addEventListener('toggle', syncState);
+    });
+};
+
 const initTechTree = () => {
     const dataElement = document.getElementById('tech-tree-data');
     const detailContainer = document.getElementById('tech-tree-detail');
@@ -520,6 +566,7 @@ const ready = () => {
     initAsyncForms();
     bootstrapResourceTicker();
     initResourcePolling();
+    initRequirementsPanels();
     initTechTree();
 };
 

--- a/templates/colony/index.php
+++ b/templates/colony/index.php
@@ -13,6 +13,7 @@ $buildings = $overview['buildings'] ?? [];
 
 $icon = require __DIR__ . '/../components/_icon.php';
 $card = require __DIR__ . '/../components/_card.php';
+$requirementsPanel = require __DIR__ . '/../components/_requirements.php';
 require_once __DIR__ . '/../components/helpers.php';
 
 $resourceLabels = [
@@ -138,7 +139,7 @@ ob_start();
                         'status' => $status,
                         'class' => 'building-card',
                         'body' => static function () use ($building, $production, $consumption, $requirements, $baseUrl,
-                                $resourceLabels, $icon): void {
+                                $resourceLabels, $icon, $requirementsPanel): void {
                             echo '<div class="building-card__sections">';
                             echo '<div class="building-card__block">';
                             echo '<h3>Prochaine amélioration</h3>';
@@ -233,17 +234,32 @@ ob_start();
                             echo '</div>';
 
                             if (!($requirements['ok'] ?? true)) {
-                                echo '<div class="building-card__block building-card__block--requirements">';
-                                echo '<h3>Pré-requis</h3>';
-                                echo '<ul class="building-card__requirements">';
-                                foreach ($requirements['missing'] as $missing) {
-                                    $label = htmlspecialchars((string) ($missing['label'] ?? $missing['key'] ?? ''));
-                                    $current = number_format((int) ($missing['current'] ?? 0));
-                                    $required = number_format((int) ($missing['level'] ?? 0));
-                                    echo '<li><span class="building-card__requirement-name">' . $label . '</span><span class="building-card__requirement-progress">(' . $current . '/' . $required . ')</span></li>';
+                                $requirementItems = [];
+                                foreach ($requirements['missing'] ?? [] as $missing) {
+                                    if (!is_array($missing)) {
+                                        continue;
+                                    }
+
+                                    $requirementItems[] = [
+                                        'label' => $missing['label'] ?? $missing['key'] ?? '',
+                                        'current' => (int) ($missing['current'] ?? 0),
+                                        'required' => (int) ($missing['level'] ?? 0),
+                                    ];
                                 }
-                                echo '</ul>';
-                                echo '</div>';
+
+                                if ($requirementItems !== []) {
+                                    echo '<div class="building-card__block building-card__block--requirements">';
+                                    echo $requirementsPanel([
+                                        'title' => 'Pré-requis',
+                                        'items' => $requirementItems,
+                                        'icon' => $icon('buildings', [
+                                            'baseUrl' => $baseUrl,
+                                            'class' => 'icon-sm requirements-panel__glyph',
+                                        ]),
+                                        'open' => true,
+                                    ]);
+                                    echo '</div>';
+                                }
                             }
 
                             echo '</div>';

--- a/templates/components/_requirements.php
+++ b/templates/components/_requirements.php
@@ -1,0 +1,102 @@
+<?php
+
+return static function (array $props): string {
+    $title = $props['title'] ?? 'Pré-requis';
+    $items = $props['items'] ?? [];
+    if (!is_array($items) || $items === []) {
+        return '';
+    }
+
+    $normalizedItems = [];
+    foreach ($items as $item) {
+        if (!is_array($item)) {
+            continue;
+        }
+
+        $label = (string) ($item['label'] ?? '');
+        $current = (int) ($item['current'] ?? ($item['currentLevel'] ?? 0));
+        $required = (int) ($item['required'] ?? ($item['level'] ?? 0));
+
+        $normalizedItems[] = [
+            'label' => $label,
+            'current' => $current,
+            'required' => $required,
+        ];
+    }
+
+    if ($normalizedItems === []) {
+        return '';
+    }
+
+    static $sequence = 0;
+    $sequence++;
+
+    $panelId = 'requirements-panel-' . $sequence;
+    $contentId = $panelId . '-content';
+    $isOpen = !empty($props['open']);
+
+    $panelClass = trim('requirements-panel ' . (string) ($props['class'] ?? ''));
+    $summaryClass = trim('requirements-panel__summary ' . (string) ($props['summaryClass'] ?? ''));
+    $contentClass = trim('requirements-panel__content ' . (string) ($props['contentClass'] ?? ''));
+    $listClass = trim('requirements-panel__list building-card__requirements ' . (string) ($props['listClass'] ?? ''));
+
+    $iconHtml = '';
+    if (isset($props['icon']) && is_string($props['icon'])) {
+        $iconHtml = $props['icon'];
+    } elseif (isset($props['iconRenderer'], $props['iconName']) && is_callable($props['iconRenderer'])) {
+        $options = $props['iconOptions'] ?? [];
+        if (!is_array($options)) {
+            $options = [];
+        }
+
+        if (!isset($options['baseUrl']) && isset($props['baseUrl'])) {
+            $options['baseUrl'] = $props['baseUrl'];
+        }
+
+        $iconHtml = (string) $props['iconRenderer']((string) $props['iconName'], $options);
+    }
+
+    $titleHtml = htmlspecialchars($title, ENT_QUOTES);
+    $summaryIcon = $iconHtml !== ''
+        ? '<span class="requirements-panel__icon">' . $iconHtml . '</span>'
+        : '';
+
+    $listItemsHtml = '';
+    foreach ($normalizedItems as $item) {
+        $label = htmlspecialchars($item['label'], ENT_QUOTES);
+        $current = number_format($item['current']);
+        $required = number_format($item['required']);
+
+        $listItemsHtml .= '<li class="requirements-panel__item">';
+        $listItemsHtml .= '<span class="requirements-panel__name building-card__requirement-name">' . $label . '</span>';
+        $listItemsHtml .= '<span class="requirements-panel__progress building-card__requirement-progress">(';
+        $listItemsHtml .= $current . '/' . $required . ')</span>';
+        $listItemsHtml .= '</li>';
+    }
+
+    $details = '<details class="' . htmlspecialchars($panelClass, ENT_QUOTES) . '" data-requirements-panel';
+    if ($isOpen) {
+        $details .= ' open';
+    }
+    $details .= '>';
+
+    $ariaExpanded = $isOpen ? 'true' : 'false';
+    $ariaHidden = $isOpen ? 'false' : 'true';
+
+    $details .= '<summary class="' . htmlspecialchars($summaryClass, ENT_QUOTES) . '" id="' . $panelId . '"';
+    $details .= ' data-requirements-summary aria-controls="' . $contentId . '" aria-expanded="' . $ariaExpanded . '">';
+    $details .= $summaryIcon;
+    $details .= '<span class="requirements-panel__title">' . $titleHtml . '</span>';
+    $details .= '<span class="requirements-panel__chevron" aria-hidden="true"></span>';
+    $details .= '</summary>';
+
+    $details .= '<div class="' . htmlspecialchars($contentClass, ENT_QUOTES) . '" id="' . $contentId . '"';
+    $details .= ' data-requirements-content role="region" aria-labelledby="' . $panelId . '" aria-hidden="' . $ariaHidden . '">';
+    $details .= '<ul class="' . htmlspecialchars($listClass, ENT_QUOTES) . '">';
+    $details .= $listItemsHtml;
+    $details .= '</ul>';
+    $details .= '</div>';
+    $details .= '</details>';
+
+    return $details;
+};

--- a/templates/research/index.php
+++ b/templates/research/index.php
@@ -9,6 +9,7 @@
 $title = $title ?? 'Laboratoire de recherche';
 $icon = require __DIR__ . '/../components/_icon.php';
 $card = require __DIR__ . '/../components/_card.php';
+$requirementsPanel = require __DIR__ . '/../components/_requirements.php';
 require_once __DIR__ . '/../components/helpers.php';
 
 $overview = $overview ?? null;
@@ -105,7 +106,7 @@ ob_start();
                         'badge' => 'Niveau ' . $level . ' / ' . ($maxLevel > 0 ? $maxLevel : '∞'),
                         'status' => $status,
                         'class' => 'tech-card',
-                        'body' => static function () use ($definition, $item, $progress, $level, $maxLevel, $baseUrl, $icon): void {
+                        'body' => static function () use ($definition, $item, $progress, $level, $maxLevel, $baseUrl, $icon, $requirementsPanel): void {
                             echo '<p class="tech-card__description">' . htmlspecialchars($definition->getDescription()) . '</p>';
                             echo '<div class="tech-card__progress">';
                             echo '<div class="progress-bar"><span class="progress-bar__value" style="width: ' . $progress . '%"></span></div>';
@@ -121,14 +122,32 @@ ob_start();
                             echo '</ul>';
                             echo '</div>';
                             if (!($item['requirements']['ok'] ?? true)) {
-                                echo '<div class="tech-card__section tech-card__requirements">';
-                                echo '<h3>Pré-requis</h3>';
-                                echo '<ul>';
-                                foreach ($item['requirements']['missing'] as $missing) {
-                                    echo '<li>' . htmlspecialchars($missing['label']) . ' (' . number_format((int) $missing['current']) . '/' . number_format((int) $missing['level']) . ')</li>';
+                                $requirementItems = [];
+                                foreach ($item['requirements']['missing'] ?? [] as $missing) {
+                                    if (!is_array($missing)) {
+                                        continue;
+                                    }
+
+                                    $requirementItems[] = [
+                                        'label' => $missing['label'] ?? $missing['key'] ?? '',
+                                        'current' => (int) ($missing['current'] ?? 0),
+                                        'required' => (int) ($missing['level'] ?? 0),
+                                    ];
                                 }
-                                echo '</ul>';
-                                echo '</div>';
+
+                                if ($requirementItems !== []) {
+                                    echo '<div class="tech-card__section">';
+                                    echo $requirementsPanel([
+                                        'title' => 'Pré-requis',
+                                        'items' => $requirementItems,
+                                        'icon' => $icon('research', [
+                                            'baseUrl' => $baseUrl,
+                                            'class' => 'icon-sm requirements-panel__glyph',
+                                        ]),
+                                        'open' => true,
+                                    ]);
+                                    echo '</div>';
+                                }
                             }
                         },
                         'footer' => static function () use ($baseUrl, $definition, $csrf_start, $selectedPlanetId, $canResearch): void {


### PR DESCRIPTION
## Summary
- add a reusable requirements panel component and adopt it on colony and research pages
- restyle requirement blocks with collapsible details, shared iconography and animations
- enhance client script to synchronize ARIA state for the new collapsible sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf13348b148332ad1af7e4456b26d3