### PR TITLE
Apply shipyard build speed bonuses

### DIFF
--- a/config/game/buildings.php
+++ b/config/game/buildings.php
@@ -161,6 +161,7 @@ return [
         'energy_use_growth' => 1.25,
         'energy_use_linear' => true,
         'affects' => 'energy',
+        'ship_build_speed_bonus' => ['base' => 0.1, 'linear' => true, 'max' => 0.9],
         'image' => 'assets/svg/illustrations/buildings/shipyard.svg',
         'requires' => [
             'buildings' => ['research_lab' => 1],

--- a/config/services.php
+++ b/config/services.php
@@ -222,7 +222,9 @@ return function (Container $container): void {
         $c->get(ShipBuildQueueRepositoryInterface::class),
         $c->get(FleetRepositoryInterface::class),
         $c->get(ShipCatalog::class),
-        $c->get(ProcessShipBuildQueue::class)
+        $c->get(ProcessShipBuildQueue::class),
+        $c->get(BuildingCatalog::class),
+        $c->get(BuildingCalculator::class)
     ));
 
     $container->set(BuildShips::class, fn (Container $c) => new BuildShips(
@@ -231,6 +233,8 @@ return function (Container $container): void {
         $c->get(ResearchStateRepositoryInterface::class),
         $c->get(ShipBuildQueueRepositoryInterface::class),
         $c->get(PlayerStatsRepositoryInterface::class),
+        $c->get(BuildingCatalog::class),
+        $c->get(BuildingCalculator::class),
         $c->get(ShipCatalog::class)
     ));
 

--- a/src/Application/UseCase/Shipyard/GetShipyardOverview.php
+++ b/src/Application/UseCase/Shipyard/GetShipyardOverview.php
@@ -3,16 +3,21 @@
 namespace App\Application\UseCase\Shipyard;
 
 use App\Application\Service\ProcessShipBuildQueue;
+use App\Domain\Entity\BuildingDefinition;
 use App\Domain\Repository\BuildingStateRepositoryInterface;
 use App\Domain\Repository\FleetRepositoryInterface;
 use App\Domain\Repository\PlanetRepositoryInterface;
 use App\Domain\Repository\ResearchStateRepositoryInterface;
 use App\Domain\Repository\ShipBuildQueueRepositoryInterface;
+use App\Domain\Service\BuildingCalculator;
+use App\Domain\Service\BuildingCatalog;
 use App\Domain\Service\ShipCatalog;
 use RuntimeException;
 
 class GetShipyardOverview
 {
+    private readonly BuildingDefinition $shipyardDefinition;
+
     public function __construct(
         private readonly PlanetRepositoryInterface $planets,
         private readonly BuildingStateRepositoryInterface $buildingStates,
@@ -20,8 +25,11 @@ class GetShipyardOverview
         private readonly ShipBuildQueueRepositoryInterface $shipQueue,
         private readonly FleetRepositoryInterface $fleets,
         private readonly ShipCatalog $catalog,
-        private readonly ProcessShipBuildQueue $queueProcessor
+        private readonly ProcessShipBuildQueue $queueProcessor,
+        BuildingCatalog $buildingCatalog,
+        private readonly BuildingCalculator $buildingCalculator
     ) {
+        $this->shipyardDefinition = $buildingCatalog->get('shipyard');
     }
 
     /**
@@ -31,7 +39,8 @@ class GetShipyardOverview
      *     fleet: array<string, int>,
      *     fleetSummary: array<int, array{key: string, label: string, quantity: int}>,
      *     queue: array{count: int, jobs: array<int, array{ship: string, label: string, quantity: int, endsAt: \DateTimeImmutable, remaining: int}>},
-     *     categories: array<int, array{label: string, image: string, items: array<int, array<string, mixed>>}>
+     *     categories: array<int, array{label: string, image: string, items: array<int, array{definition: \App\Domain\Entity\ShipDefinition, requirements: array{ok: bool, missing: array<int, array{type: string, key: string, label: string, level: int, current: int}>}, canBuild: bool, buildTime: int, baseBuildTime: int}>>,
+     *     shipyardBonus: float
      * }
      */
     public function execute(int $planetId): array
@@ -45,6 +54,7 @@ class GetShipyardOverview
 
         $buildingLevels = $this->buildingStates->getLevels($planetId);
         $shipyardLevel = $buildingLevels['shipyard'] ?? 0;
+        $shipyardBonus = $this->buildingCalculator->shipBuildSpeedBonus($this->shipyardDefinition, $shipyardLevel);
         $researchLevels = $this->researchStates->getLevels($planetId);
         $catalogMap = [];
         foreach ($this->catalog->all() as $definition) {
@@ -86,10 +96,18 @@ class GetShipyardOverview
                 $requirements = $this->checkRequirements($definition->getRequiresResearch(), $researchLevels, $catalogMap);
                 $canBuild = $shipyardLevel > 0 && $requirements['ok'] && !$queueLimitReached;
 
+                $buildTime = $this->buildingCalculator->applyShipBuildSpeedBonus(
+                    $this->shipyardDefinition,
+                    $shipyardLevel,
+                    $definition->getBuildTime()
+                );
+
                 $items[] = [
                     'definition' => $definition,
                     'requirements' => $requirements,
                     'canBuild' => $canBuild,
+                    'buildTime' => $buildTime,
+                    'baseBuildTime' => $definition->getBuildTime(),
                 ];
             }
 
@@ -111,6 +129,7 @@ class GetShipyardOverview
                 'jobs' => $queueView,
             ],
             'categories' => $categories,
+            'shipyardBonus' => $shipyardBonus,
         ];
     }
 

--- a/src/Domain/Entity/BuildingDefinition.php
+++ b/src/Domain/Entity/BuildingDefinition.php
@@ -6,6 +6,7 @@ class BuildingDefinition
 {
     /** @param array<string, int> $baseCost */
     /** @param array{buildings?: array<string, int>, research?: array<string, int>} $requirements */
+    /** @param array{base?: float, growth?: float, linear?: bool, max?: float} $shipBuildSpeedBonus */
     /** @param array<string, array{base: float, growth: float}> $storage */
     /** @param array<string, array{base?: float, growth?: float, linear?: bool}> $upkeep */
     public function __construct(
@@ -23,6 +24,7 @@ class BuildingDefinition
         private readonly string $affects,
         private readonly array $requirements = [],
         private readonly ?string $image = null,
+        private readonly array $shipBuildSpeedBonus = [],
         private readonly array $storage = [],
         private readonly array $upkeep = []
     ) {
@@ -98,6 +100,14 @@ class BuildingDefinition
     public function getImage(): ?string
     {
         return $this->image;
+    }
+
+    /**
+     * @return array{base?: float, growth?: float, linear?: bool, max?: float}
+     */
+    public function getShipBuildSpeedBonusConfig(): array
+    {
+        return $this->shipBuildSpeedBonus;
     }
 
     /**

--- a/src/Domain/Service/BuildingCalculator.php
+++ b/src/Domain/Service/BuildingCalculator.php
@@ -102,6 +102,63 @@ class BuildingCalculator
         return $upkeep;
     }
 
+    public function shipBuildSpeedBonus(BuildingDefinition $definition, int $level): float
+    {
+        if ($level <= 0) {
+            return 0.0;
+        }
+
+        $config = $definition->getShipBuildSpeedBonusConfig();
+        if ($config === []) {
+            return 0.0;
+        }
+
+        $base = (float) ($config['base'] ?? 0.0);
+        if ($base <= 0.0) {
+            return 0.0;
+        }
+
+        $bonus = $base;
+        $growth = (float) ($config['growth'] ?? 1.0);
+        if ($level > 1 && $growth !== 1.0) {
+            $bonus *= pow($growth, $level - 1);
+        }
+
+        if (!empty($config['linear'])) {
+            $bonus *= $level;
+        }
+
+        if (isset($config['max'])) {
+            $max = (float) $config['max'];
+            if ($max > 0.0) {
+                $bonus = min($bonus, $max);
+            }
+        }
+
+        return max(0.0, $bonus);
+    }
+
+    public function applyShipBuildSpeedBonus(BuildingDefinition $definition, int $level, int $baseTime): int
+    {
+        if ($baseTime <= 0) {
+            return 1;
+        }
+
+        $bonus = $this->shipBuildSpeedBonus($definition, $level);
+        if ($bonus <= 0.0) {
+            return max(1, $baseTime);
+        }
+
+        $modifier = 1.0 + $bonus;
+        if ($modifier <= 0.0) {
+            return max(1, $baseTime);
+        }
+
+        $time = (int) floor($baseTime / $modifier);
+
+        return max(1, $time);
+    }
+
     /**
      * @return array<string, int>
      */

--- a/src/Domain/Service/BuildingCatalog.php
+++ b/src/Domain/Service/BuildingCatalog.php
@@ -31,6 +31,7 @@ class BuildingCatalog
                 $data['affects'],
                 $data['requires'] ?? [],
                 $data['image'] ?? null,
+                $data['ship_build_speed_bonus'] ?? [],
                 $data['storage'] ?? [],
                 $data['upkeep'] ?? []
             );

--- a/templates/shipyard/index.php
+++ b/templates/shipyard/index.php
@@ -17,6 +17,7 @@ $fleet = $overview['fleet'] ?? [];
 $fleetSummary = $overview['fleetSummary'] ?? [];
 $categories = $overview['categories'] ?? [];
 $shipyardLevel = $overview['shipyardLevel'] ?? 0;
+$shipyardBonus = (float) ($overview['shipyardBonus'] ?? 0);
 $fleetCount = 0;
 if (!empty($fleetSummary)) {
     foreach ($fleetSummary as $ship) {
@@ -57,9 +58,14 @@ ob_start();
     <?= $card([
         'title' => 'Commandes de vaisseaux',
         'subtitle' => 'Suivi des constructions orbitales',
-        'body' => static function () use ($queue, $shipyardLevel): void {
+        'body' => static function () use ($queue, $shipyardLevel, $shipyardBonus): void {
             $emptyMessage = 'Aucune commande de vaisseau n’est en file. Lancez une production pour étoffer votre flotte.';
             echo '<p class="metric-line"><span class="metric-line__label">Niveau du chantier</span><span class="metric-line__value">' . number_format((int) $shipyardLevel) . '</span></p>';
+            if ($shipyardBonus > 0) {
+                $bonusPercent = $shipyardBonus * 100;
+                $bonusDisplay = rtrim(rtrim(number_format($bonusPercent, 1), '0'), '.');
+                echo '<p class="metric-line"><span class="metric-line__label">Bonus de vitesse</span><span class="metric-line__value metric-line__value--positive">+' . htmlspecialchars($bonusDisplay) . ' %</span></p>';
+            }
             echo '<div class="queue-block" data-queue="shipyard" data-empty="' . htmlspecialchars($emptyMessage, ENT_QUOTES) . '">';
             if (($queue['count'] ?? 0) === 0) {
                 echo '<p class="empty-state">' . htmlspecialchars($emptyMessage) . '</p>';
@@ -94,6 +100,8 @@ ob_start();
                     <?php
                     $definition = $item['definition'];
                     $canBuild = (bool) ($item['canBuild'] ?? false);
+                    $buildTime = (int) ($item['buildTime'] ?? $definition->getBuildTime());
+                    $baseBuildTime = (int) ($item['baseBuildTime'] ?? $definition->getBuildTime());
                     ?>
                     <article class="ship-card<?= $canBuild ? '' : ' is-locked' ?>">
                         <header class="ship-card__header">
@@ -119,7 +127,7 @@ ob_start();
                                     <?php foreach ($definition->getBaseCost() as $resource => $amount): ?>
                                         <li><?= $icon((string) $resource, ['baseUrl' => $baseUrl, 'class' => 'icon-sm']) ?><span><?= number_format((int) $amount) ?></span></li>
                                     <?php endforeach; ?>
-                                    <li><?= $icon('time', ['baseUrl' => $baseUrl, 'class' => 'icon-sm']) ?><span><?= htmlspecialchars(format_duration((int) $definition->getBuildTime())) ?></span></li>
+                                    <li><?= $icon('time', ['baseUrl' => $baseUrl, 'class' => 'icon-sm']) ?><span><?= htmlspecialchars(format_duration($buildTime)) ?><?php if ($baseBuildTime !== $buildTime): ?> <small>(base <?= htmlspecialchars(format_duration($baseBuildTime)) ?>)</small><?php endif; ?></span></li>
                                 </ul>
                             </div>
                             <?php if (!($item['requirements']['ok'] ?? true)): ?>

--- a/tests/Integration/QueueProcessingTest.php
+++ b/tests/Integration/QueueProcessingTest.php
@@ -8,6 +8,7 @@ use App\Application\Service\ProcessShipBuildQueue;
 use App\Application\UseCase\Building\UpgradeBuilding;
 use App\Application\UseCase\Research\StartResearch;
 use App\Application\UseCase\Shipyard\BuildShips;
+use App\Application\UseCase\Shipyard\GetShipyardOverview;
 use App\Controller\ResourceApiController;
 use App\Domain\Entity\Planet;
 use App\Domain\Repository\BuildingStateRepositoryInterface;
@@ -148,6 +149,23 @@ class QueueProcessingTest extends TestCase
         ]);
         $shipQueue = new InMemoryShipBuildQueueRepository();
         $fleetRepository = new InMemoryFleetRepository();
+        $buildingCatalog = new BuildingCatalog([
+            'shipyard' => [
+                'label' => 'Chantier',
+                'base_cost' => ['metal' => 100],
+                'growth_cost' => 1.0,
+                'base_time' => 1,
+                'growth_time' => 1.0,
+                'prod_base' => 0,
+                'prod_growth' => 1.0,
+                'energy_use_base' => 0,
+                'energy_use_growth' => 1.0,
+                'energy_use_linear' => false,
+                'affects' => 'energy',
+                'ship_build_speed_bonus' => ['base' => 0.1, 'linear' => true, 'max' => 0.9],
+            ],
+        ]);
+        $buildingCalculator = new BuildingCalculator();
         $catalog = new ShipCatalog([
             'fighter' => [
                 'label' => 'Chasseur',
@@ -163,13 +181,15 @@ class QueueProcessingTest extends TestCase
         ]);
 
         $playerStats = new InMemoryPlayerStatsRepository();
-        $useCase = new BuildShips($planetRepository, $buildingStates, $researchStates, $shipQueue, $playerStats, $catalog);
+        $useCase = new BuildShips($planetRepository, $buildingStates, $researchStates, $shipQueue, $playerStats, $buildingCatalog, $buildingCalculator, $catalog);
         $processor = new ProcessShipBuildQueue($shipQueue, $fleetRepository);
 
         $result = $useCase->execute(1, 42, 'fighter', 3);
         self::assertTrue($result['success']);
         self::assertSame([], $fleetRepository->getFleet(1));
         self::assertSame(1, $shipQueue->countActive(1));
+        $expectedPerUnit = max(1, (int) floor(4 / (1 + 0.1 * 2)));
+        self::assertSame($expectedPerUnit * 3, $shipQueue->getLastDuration(1));
 
         $shipQueue->forceComplete(1);
         $processor->process(1);
@@ -177,6 +197,141 @@ class QueueProcessingTest extends TestCase
         self::assertSame(['fighter' => 3], $fleetRepository->getFleet(1));
         self::assertSame(0, $shipQueue->countActive(1));
         self::assertSame(600, $playerStats->getScienceSpending(42));
+    }
+
+    public function testShipProductionDurationRespectsMinimumPerUnit(): void
+    {
+        $planetRepository = new InMemoryPlanetRepository([
+            1 => new Planet(1, 84, 1, 1, 1, 'Gaia', 5000, 5000, 5000, 0, 0, 0, 0, 0, 100000, 100000, 100000, 1000, new DateTimeImmutable()),
+        ]);
+        $buildingStates = new InMemoryBuildingStateRepository([
+            1 => ['shipyard' => 12],
+        ]);
+        $researchStates = new InMemoryResearchStateRepository([
+            1 => [],
+        ]);
+        $shipQueue = new InMemoryShipBuildQueueRepository();
+        $fleetRepository = new InMemoryFleetRepository();
+        $buildingCatalog = new BuildingCatalog([
+            'shipyard' => [
+                'label' => 'Chantier',
+                'base_cost' => ['metal' => 100],
+                'growth_cost' => 1.0,
+                'base_time' => 1,
+                'growth_time' => 1.0,
+                'prod_base' => 0,
+                'prod_growth' => 1.0,
+                'energy_use_base' => 0,
+                'energy_use_growth' => 1.0,
+                'energy_use_linear' => false,
+                'affects' => 'energy',
+                'ship_build_speed_bonus' => ['base' => 0.1, 'linear' => true, 'max' => 0.9],
+            ],
+        ]);
+        $buildingCalculator = new BuildingCalculator();
+        $catalog = new ShipCatalog([
+            'probe' => [
+                'label' => 'Sonde',
+                'category' => 'Divers',
+                'role' => 'Exploration',
+                'description' => '',
+                'base_cost' => ['metal' => 20],
+                'build_time' => 1,
+                'stats' => [],
+                'requires_research' => [],
+                'image' => '',
+            ],
+        ]);
+
+        $playerStats = new InMemoryPlayerStatsRepository();
+        $buildShips = new BuildShips($planetRepository, $buildingStates, $researchStates, $shipQueue, $playerStats, $buildingCatalog, $buildingCalculator, $catalog);
+
+        $result = $buildShips->execute(1, 84, 'probe', 5);
+        self::assertTrue($result['success']);
+        self::assertSame(1, $shipQueue->countActive(1));
+        self::assertSame(5, $shipQueue->getLastDuration(1));
+    }
+
+    public function testShipyardOverviewReflectsSpeedBonus(): void
+    {
+        $planetRepository = new InMemoryPlanetRepository([
+            1 => new Planet(1, 55, 1, 1, 1, 'Gaia', 5000, 5000, 5000, 0, 0, 0, 0, 0, 100000, 100000, 100000, 1000, new DateTimeImmutable()),
+        ]);
+        $buildingStates = new InMemoryBuildingStateRepository([
+            1 => ['shipyard' => 3],
+        ]);
+        $researchStates = new InMemoryResearchStateRepository([
+            1 => [],
+        ]);
+        $shipQueue = new InMemoryShipBuildQueueRepository();
+        $fleetRepository = new InMemoryFleetRepository();
+        $buildingCatalog = new BuildingCatalog([
+            'shipyard' => [
+                'label' => 'Chantier',
+                'base_cost' => ['metal' => 100],
+                'growth_cost' => 1.0,
+                'base_time' => 1,
+                'growth_time' => 1.0,
+                'prod_base' => 0,
+                'prod_growth' => 1.0,
+                'energy_use_base' => 0,
+                'energy_use_growth' => 1.0,
+                'energy_use_linear' => false,
+                'affects' => 'energy',
+                'ship_build_speed_bonus' => ['base' => 0.1, 'linear' => true, 'max' => 0.9],
+            ],
+        ]);
+        $buildingCalculator = new BuildingCalculator();
+        $catalog = new ShipCatalog([
+            'fighter' => [
+                'label' => 'Chasseur',
+                'category' => 'Escadre',
+                'role' => 'Intercepteur',
+                'description' => '',
+                'base_cost' => ['metal' => 200],
+                'build_time' => 10,
+                'stats' => [],
+                'requires_research' => [],
+                'image' => '',
+            ],
+        ]);
+        $queueProcessor = new ProcessShipBuildQueue($shipQueue, $fleetRepository);
+
+        $overviewUseCase = new GetShipyardOverview(
+            $planetRepository,
+            $buildingStates,
+            $researchStates,
+            $shipQueue,
+            $fleetRepository,
+            $catalog,
+            $queueProcessor,
+            $buildingCatalog,
+            $buildingCalculator
+        );
+
+        $overview = $overviewUseCase->execute(1);
+        $shipyardDefinition = $buildingCatalog->get('shipyard');
+        $expectedBonus = $buildingCalculator->shipBuildSpeedBonus($shipyardDefinition, 3);
+        $expectedBuildTime = $buildingCalculator->applyShipBuildSpeedBonus($shipyardDefinition, 3, 10);
+
+        $foundBuildTime = null;
+        $foundBaseTime = null;
+        foreach ($overview['categories'] as $category) {
+            foreach ($category['items'] as $item) {
+                $definition = $item['definition'];
+                if ($definition->getKey() === 'fighter') {
+                    $foundBuildTime = $item['buildTime'] ?? null;
+                    $foundBaseTime = $item['baseBuildTime'] ?? null;
+                    break 2;
+                }
+            }
+        }
+
+        self::assertNotNull($foundBuildTime);
+        self::assertNotNull($foundBaseTime);
+        self::assertSame($expectedBuildTime, $foundBuildTime);
+        self::assertSame(10, $foundBaseTime);
+        self::assertEqualsWithDelta($expectedBonus, $overview['shipyardBonus'], 0.0001);
     }
 
     public function testBuildingQueueSequentialTargets(): void
@@ -561,6 +716,23 @@ class QueueProcessingTest extends TestCase
         ]);
         $shipQueue = new InMemoryShipBuildQueueRepository();
         $fleetRepository = new InMemoryFleetRepository();
+        $buildingCatalog = new BuildingCatalog([
+            'shipyard' => [
+                'label' => 'Chantier',
+                'base_cost' => ['metal' => 100],
+                'growth_cost' => 1.0,
+                'base_time' => 1,
+                'growth_time' => 1.0,
+                'prod_base' => 0,
+                'prod_growth' => 1.0,
+                'energy_use_base' => 0,
+                'energy_use_growth' => 1.0,
+                'energy_use_linear' => false,
+                'affects' => 'energy',
+                'ship_build_speed_bonus' => ['base' => 0.1, 'linear' => true, 'max' => 0.9],
+            ],
+        ]);
+        $buildingCalculator = new BuildingCalculator();
         $catalog = new ShipCatalog([
             'fighter' => [
                 'label' => 'Chasseur',
@@ -576,7 +748,7 @@ class QueueProcessingTest extends TestCase
         ]);
 
         $playerStats = new InMemoryPlayerStatsRepository();
-        $buildShips = new BuildShips($planetRepository, $buildingStates, $researchStates, $shipQueue, $playerStats, $catalog);
+        $buildShips = new BuildShips($planetRepository, $buildingStates, $researchStates, $shipQueue, $playerStats, $buildingCatalog, $buildingCalculator, $catalog);
         $shipProcessor = new ProcessShipBuildQueue($shipQueue, $fleetRepository);
 
         $result = $buildShips->execute(1, 7, 'fighter', 4);
@@ -887,7 +1059,7 @@ class InMemoryResearchQueueRepository implements ResearchQueueRepositoryInterfac
  */
 class InMemoryShipBuildQueueRepository implements ShipBuildQueueRepositoryInterface
 {
-    /** @var array<int, array{planet_id: int, ship: string, quantity: int, ends_at: \DateTimeImmutable}> */
+    /** @var array<int, array{planet_id: int, ship: string, quantity: int, ends_at: \DateTimeImmutable, duration: int}> */
     private array $jobs = [];
     private int $nextId = 1;
 
@@ -924,7 +1096,20 @@ class InMemoryShipBuildQueueRepository implements ShipBuildQueueRepositoryInterf
             'ship' => $shipKey,
             'quantity' => $quantity,
             'ends_at' => (new \DateTimeImmutable())->modify('+' . $durationSeconds . ' seconds'),
+            'duration' => $durationSeconds,
         ];
+    }
+
+    public function getLastDuration(int $planetId): ?int
+    {
+        for ($i = count($this->jobs) - 1; $i >= 0; $i--) {
+            $job = $this->jobs[$i];
+            if ($job['planet_id'] === $planetId) {
+                return $job['duration'] ?? null;
+            }
+        }
+
+        return null;
     }
 
     public function finalizeDueJobs(int $planetId): array

--- a/tests/Unit/BuildingCalculatorTest.php
+++ b/tests/Unit/BuildingCalculatorTest.php
@@ -70,6 +70,7 @@ class BuildingCalculatorTest extends TestCase
             [],
             null,
             [],
+            [],
             ['hydrogen' => ['base' => 30, 'growth' => 1.16]]
         );
 


### PR DESCRIPTION
## Summary
- add a ship build speed bonus configuration to the shipyard and expose it through the domain catalog/calculator
- apply the bonus when queuing ship production and surface the adjusted timings plus bonus details in the shipyard overview/UI
- expand integration tests to cover speed bonuses and minimum durations while adapting unit tests to the new catalog contract

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68cf132b77f48332afa88e1fde5fd379