### PR TITLE
Use root-relative asset paths

### DIFF
--- a/templates/components/_icon.php
+++ b/templates/components/_icon.php
@@ -1,7 +1,6 @@
 <?php
 
 return static function (string $name, array $options = []): string {
-    $baseUrl = $options['baseUrl'] ?? '';
     $label = $options['label'] ?? null;
     $classes = trim('icon ' . ($options['class'] ?? ''));
     $size = $options['size'] ?? null;
@@ -36,8 +35,9 @@ return static function (string $name, array $options = []): string {
         $attributeString .= sprintf(' %s="%s"', $attributeKey, htmlspecialchars((string) $value, ENT_QUOTES));
     }
 
-    $href = rtrim($baseUrl, '/') . '/assets/svg/sprite.svg#icon-' . htmlspecialchars($name, ENT_QUOTES);
-    $svg = sprintf('<svg%s><use href="%s"></use></svg>', $attributeString, $href);
+    $iconName = (string) $name;
+    $href = '/assets/svg/sprite.svg#icon-' . $iconName;
+    $svg = sprintf('<svg%s><use href="%s"></use></svg>', $attributeString, htmlspecialchars($href, ENT_QUOTES));
 
     if ($label) {
         $svg .= sprintf('<span class="visually-hidden">%s</span>', htmlspecialchars((string) $label, ENT_QUOTES));

--- a/templates/components/_resource_bar.php
+++ b/templates/components/_resource_bar.php
@@ -9,7 +9,6 @@ return static function (array $resources, array $options = []): string {
         return '';
     }
 
-    $baseUrl = $options['baseUrl'] ?? '';
     $showRates = (bool) ($options['showRates'] ?? true);
     $class = trim('resource-bar ' . ($options['class'] ?? ''));
 
@@ -39,9 +38,10 @@ return static function (array $resources, array $options = []): string {
             $rateClass = $trend;
         }
 
+        $iconHref = '/assets/svg/sprite.svg#icon-' . (string) $key;
         $icon = sprintf(
             '<svg class="icon icon-sm" aria-hidden="true"><use href="%s"></use></svg>',
-            rtrim($baseUrl, '/') . '/assets/svg/sprite.svg#icon-' . htmlspecialchars((string) $key, ENT_QUOTES)
+            htmlspecialchars($iconHref, ENT_QUOTES)
         );
 
         $hintMarkup = '';

--- a/templates/galaxy/index.php
+++ b/templates/galaxy/index.php
@@ -132,7 +132,7 @@ ob_start();
             } else {
                 $planet = $slot['planet'];
                 echo '<div class="galaxy-slot__title">';
-                echo '<svg class="icon icon-sm" aria-hidden="true"><use href="' . htmlspecialchars($baseUrl) . '/assets/svg/sprite.svg#icon-planet"></use></svg>';
+                echo '<svg class="icon icon-sm" aria-hidden="true"><use href="/assets/svg/sprite.svg#icon-planet"></use></svg>';
                 echo '<h3>' . htmlspecialchars($planet ? $planet->getName() : 'Planète inconnue') . '</h3>';
                 echo '</div>';
                 echo '<div class="galaxy-slot__meta">';

--- a/templates/layouts/base.php
+++ b/templates/layouts/base.php
@@ -20,9 +20,9 @@ if ($assetBase === '') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($title ?? 'Genesis Reborn') ?></title>
-    <link rel="preload" href="<?= htmlspecialchars($assetBase) ?>/assets/svg/sprite.svg" as="image" type="image/svg+xml">
-    <link rel="stylesheet" href="<?= htmlspecialchars($assetBase) ?>/assets/css/tokens.css">
-    <link rel="stylesheet" href="<?= htmlspecialchars($assetBase) ?>/assets/css/app.css">
+    <link rel="preload" href="/assets/svg/sprite.svg" as="image" type="image/svg+xml">
+    <link rel="stylesheet" href="/assets/css/tokens.css">
+    <link rel="stylesheet" href="/assets/css/app.css">
 </head>
 <?php
 $planets = $planets ?? [];
@@ -125,7 +125,7 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                                 <li class="sidebar__item <?= $isCurrent ? 'is-active' : '' ?>">
                                     <<?= $tag . $linkAttributes ?>>
                                         <svg class="icon icon-sm" aria-hidden="true">
-                                            <use href="<?= htmlspecialchars($assetBase) ?>/assets/svg/sprite.svg#icon-<?= htmlspecialchars($item['icon']) ?>"></use>
+                                            <use href="/assets/svg/sprite.svg#icon-<?= htmlspecialchars($item['icon'], ENT_QUOTES) ?>"></use>
                                         </svg>
                                         <span><?= htmlspecialchars($item['label']) ?></span>
                                         <?php if ($isLocked): ?>
@@ -181,7 +181,7 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                         <div class="<?= $meterClasses ?>" role="group" aria-label="<?= htmlspecialchars($label) ?>" data-resource="<?= htmlspecialchars($key) ?>" data-resource-capacity="<?= $capacityValue ?>">
                             <div class="resource-meter__icon">
                                 <svg class="icon icon-sm" aria-hidden="true">
-                                    <use href="<?= htmlspecialchars($assetBase) ?>/assets/svg/sprite.svg#icon-<?= htmlspecialchars($key) ?>"></use>
+                                    <use href="/assets/svg/sprite.svg#icon-<?= htmlspecialchars($key, ENT_QUOTES) ?>"></use>
                                 </svg>
                             </div>
                             <div class="resource-meter__details">
@@ -202,7 +202,7 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_logout ?? '') ?>">
                             <button type="submit" class="button button--ghost">
                                 <svg class="icon icon-sm" aria-hidden="true">
-                                    <use href="<?= htmlspecialchars($assetBase) ?>/assets/svg/sprite.svg#icon-logout"></use>
+                                    <use href="/assets/svg/sprite.svg#icon-logout"></use>
                                 </svg>
                                 <span>Déconnexion</span>
                             </button>
@@ -236,6 +236,6 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
         </footer>
     </div>
 </div>
-<script type="module" src="<?= htmlspecialchars($assetBase) ?>/assets/js/app.js"></script>
+<script type="module" src="/assets/js/app.js"></script>
 </body>
 </html>

--- a/templates/pages/dashboard/index.php
+++ b/templates/pages/dashboard/index.php
@@ -168,7 +168,7 @@ ob_start();
                                 <li>
                                     <div class="planet-summary__resource-label">
                                         <svg class="icon icon-sm" aria-hidden="true">
-                                            <use href="<?= htmlspecialchars($baseUrl) ?>/assets/svg/sprite.svg#icon-<?= htmlspecialchars($meta['icon']) ?>"></use>
+                                            <use href="/assets/svg/sprite.svg#icon-<?= htmlspecialchars($meta['icon'], ENT_QUOTES) ?>"></use>
                                         </svg>
                                         <span><?= htmlspecialchars($meta['label']) ?></span>
                                     </div>


### PR DESCRIPTION
## Summary
- ensure the base layout loads CSS/JS and icons from root-relative asset URLs
- update shared icon/resource helpers and page templates to reference the sprite without relying on baseUrl state

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cf2493a5308332bd50cc3e164102a0