### PR TITLE
Fix asset URL handling in templates

### DIFF
--- a/templates/components/_icon.php
+++ b/templates/components/_icon.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/helpers.php';
+
 return static function (string $name, array $options = []): string {
     $label = $options['label'] ?? null;
     $classes = trim('icon ' . ($options['class'] ?? ''));
@@ -36,7 +38,8 @@ return static function (string $name, array $options = []): string {
     }
 
     $iconName = (string) $name;
-    $href = '/assets/svg/sprite.svg#icon-' . $iconName;
+    $baseUrl = $options['baseUrl'] ?? null;
+    $href = asset_url('assets/svg/sprite.svg#icon-' . $iconName, is_string($baseUrl) ? $baseUrl : null);
     $svg = sprintf('<svg%s><use href="%s"></use></svg>', $attributeString, htmlspecialchars($href, ENT_QUOTES));
 
     if ($label) {

--- a/templates/components/_resource_bar.php
+++ b/templates/components/_resource_bar.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/helpers.php';
+
 /**
  * @param array<string, array{label: string, value: int|float, perHour?: int|float, hint?: string, trend?: string}> $resources
  * @param array{baseUrl?: string, class?: string, showRates?: bool} $options
@@ -11,6 +13,8 @@ return static function (array $resources, array $options = []): string {
 
     $showRates = (bool) ($options['showRates'] ?? true);
     $class = trim('resource-bar ' . ($options['class'] ?? ''));
+    $baseUrlOption = $options['baseUrl'] ?? null;
+    $assetBase = is_string($baseUrlOption) ? $baseUrlOption : null;
 
     $items = '';
     foreach ($resources as $key => $data) {
@@ -38,7 +42,7 @@ return static function (array $resources, array $options = []): string {
             $rateClass = $trend;
         }
 
-        $iconHref = '/assets/svg/sprite.svg#icon-' . (string) $key;
+        $iconHref = asset_url('assets/svg/sprite.svg#icon-' . (string) $key, $assetBase);
         $icon = sprintf(
             '<svg class="icon icon-sm" aria-hidden="true"><use href="%s"></use></svg>',
             htmlspecialchars($iconHref, ENT_QUOTES)

--- a/templates/components/helpers.php
+++ b/templates/components/helpers.php
@@ -22,3 +22,36 @@ if (!function_exists('format_duration')) {
         return implode(' ', $parts);
     }
 }
+
+if (!function_exists('asset_url')) {
+    /**
+     * Build an absolute asset URL based on the provided base URL.
+     */
+    function asset_url(string $path, ?string $baseUrl = null): string
+    {
+        $trimmedPath = trim($path);
+        if ($trimmedPath === '') {
+            return '';
+        }
+
+        // Absolute URLs or protocol-relative paths are returned as-is.
+        if (preg_match('/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i', $trimmedPath) === 1) {
+            return $trimmedPath;
+        }
+
+        if ($trimmedPath[0] === '#') {
+            return $trimmedPath;
+        }
+
+        $prefix = '';
+        if (is_string($baseUrl) && $baseUrl !== '') {
+            $prefix = rtrim($baseUrl, '/');
+        }
+
+        if ($trimmedPath[0] !== '/') {
+            $trimmedPath = '/' . $trimmedPath;
+        }
+
+        return $prefix !== '' ? $prefix . $trimmedPath : $trimmedPath;
+    }
+}

--- a/templates/galaxy/index.php
+++ b/templates/galaxy/index.php
@@ -10,6 +10,9 @@
 
 $title = $title ?? 'Carte galaxie';
 $card = require __DIR__ . '/../components/_card.php';
+require_once __DIR__ . '/../components/helpers.php';
+
+$spriteIcon = static fn (string $name): string => asset_url('assets/svg/sprite.svg#icon-' . $name, $baseUrl ?? '');
 
 if (!function_exists('format_relative_time')) {
     function format_relative_time(\DateTimeImmutable $date, \DateTimeImmutable $now): string
@@ -93,7 +96,7 @@ ob_start();
 <?= $card([
     'title' => sprintf('Système %d:%d', (int) ($summary['galaxy'] ?? 0), (int) ($summary['system'] ?? 0)),
     'subtitle' => 'Visualisation détaillée des orbites et des dernières activités',
-    'body' => static function () use ($slots, $baseUrl, $now): void {
+    'body' => static function () use ($slots, $baseUrl, $now, $spriteIcon): void {
         if ($slots === []) {
             echo '<p class="empty-state">Aucune donnée disponible pour ce système.</p>';
 
@@ -132,7 +135,8 @@ ob_start();
             } else {
                 $planet = $slot['planet'];
                 echo '<div class="galaxy-slot__title">';
-                echo '<svg class="icon icon-sm" aria-hidden="true"><use href="/assets/svg/sprite.svg#icon-planet"></use></svg>';
+                $planetIconHref = htmlspecialchars($spriteIcon('planet'), ENT_QUOTES);
+                echo '<svg class="icon icon-sm" aria-hidden="true"><use href="' . $planetIconHref . '"></use></svg>';
                 echo '<h3>' . htmlspecialchars($planet ? $planet->getName() : 'Planète inconnue') . '</h3>';
                 echo '</div>';
                 echo '<div class="galaxy-slot__meta">';

--- a/templates/layouts/base.php
+++ b/templates/layouts/base.php
@@ -9,10 +9,13 @@
 /** @var string|null $activeSection */
 /** @var int|null $selectedPlanetId */
 
-$assetBase = rtrim($baseUrl ?? '', '/');
-if ($assetBase === '') {
-    $assetBase = '';
-}
+require_once __DIR__ . '/../components/helpers.php';
+
+$baseUrl = $baseUrl ?? '';
+$assetBase = rtrim($baseUrl, '/');
+$asset = static fn (string $path): string => asset_url($path, $assetBase);
+$spriteHref = $asset('assets/svg/sprite.svg');
+$spriteIcon = static fn (string $name): string => $asset('assets/svg/sprite.svg#icon-' . $name);
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -20,9 +23,9 @@ if ($assetBase === '') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($title ?? 'Genesis Reborn') ?></title>
-    <link rel="preload" href="/assets/svg/sprite.svg" as="image" type="image/svg+xml">
-    <link rel="stylesheet" href="/assets/css/tokens.css">
-    <link rel="stylesheet" href="/assets/css/app.css">
+    <link rel="preload" href="<?= htmlspecialchars($spriteHref, ENT_QUOTES) ?>" as="image" type="image/svg+xml">
+    <link rel="stylesheet" href="<?= htmlspecialchars($asset('assets/css/tokens.css'), ENT_QUOTES) ?>">
+    <link rel="stylesheet" href="<?= htmlspecialchars($asset('assets/css/app.css'), ENT_QUOTES) ?>">
 </head>
 <?php
 $planets = $planets ?? [];
@@ -125,7 +128,7 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                                 <li class="sidebar__item <?= $isCurrent ? 'is-active' : '' ?>">
                                     <<?= $tag . $linkAttributes ?>>
                                         <svg class="icon icon-sm" aria-hidden="true">
-                                            <use href="/assets/svg/sprite.svg#icon-<?= htmlspecialchars($item['icon'], ENT_QUOTES) ?>"></use>
+                                            <use href="<?= htmlspecialchars($spriteIcon($item['icon']), ENT_QUOTES) ?>"></use>
                                         </svg>
                                         <span><?= htmlspecialchars($item['label']) ?></span>
                                         <?php if ($isLocked): ?>
@@ -181,7 +184,7 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                         <div class="<?= $meterClasses ?>" role="group" aria-label="<?= htmlspecialchars($label) ?>" data-resource="<?= htmlspecialchars($key) ?>" data-resource-capacity="<?= $capacityValue ?>">
                             <div class="resource-meter__icon">
                                 <svg class="icon icon-sm" aria-hidden="true">
-                                    <use href="/assets/svg/sprite.svg#icon-<?= htmlspecialchars($key, ENT_QUOTES) ?>"></use>
+                                    <use href="<?= htmlspecialchars($spriteIcon($key), ENT_QUOTES) ?>"></use>
                                 </svg>
                             </div>
                             <div class="resource-meter__details">
@@ -202,7 +205,7 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_logout ?? '') ?>">
                             <button type="submit" class="button button--ghost">
                                 <svg class="icon icon-sm" aria-hidden="true">
-                                    <use href="/assets/svg/sprite.svg#icon-logout"></use>
+                                    <use href="<?= htmlspecialchars($spriteIcon('logout'), ENT_QUOTES) ?>"></use>
                                 </svg>
                                 <span>Déconnexion</span>
                             </button>
@@ -236,6 +239,6 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
         </footer>
     </div>
 </div>
-<script type="module" src="/assets/js/app.js"></script>
+<script type="module" src="<?= htmlspecialchars($asset('assets/js/app.js'), ENT_QUOTES) ?>"></script>
 </body>
 </html>

--- a/templates/pages/dashboard/index.php
+++ b/templates/pages/dashboard/index.php
@@ -10,6 +10,8 @@
 $title = $title ?? 'Vue d’ensemble';
 require_once __DIR__ . '/../../components/helpers.php';
 
+$spriteIcon = static fn (string $name): string => asset_url('assets/svg/sprite.svg#icon-' . $name, $baseUrl ?? '');
+
 $empire = $dashboard['empire'] ?? [
     'points' => 0,
     'buildingPoints' => 0,
@@ -168,7 +170,7 @@ ob_start();
                                 <li>
                                     <div class="planet-summary__resource-label">
                                         <svg class="icon icon-sm" aria-hidden="true">
-                                            <use href="/assets/svg/sprite.svg#icon-<?= htmlspecialchars($meta['icon'], ENT_QUOTES) ?>"></use>
+                                            <use href="<?= htmlspecialchars($spriteIcon($meta['icon']), ENT_QUOTES) ?>"></use>
                                         </svg>
                                         <span><?= htmlspecialchars($meta['label']) ?></span>
                                     </div>


### PR DESCRIPTION
## Summary
- add an `asset_url` helper and use it in the base layout so CSS/JS assets resolve against the configured base URL
- update shared icon/resource components along with the galaxy and dashboard templates to use the helper for sprite icons

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cf2781711c833281150f8e6e9999b5