### PR TITLE
Fix requirements panel closures

### DIFF
--- a/templates/colony/index.php
+++ b/templates/colony/index.php
@@ -145,8 +145,16 @@ ob_start();
                         'attributes' => [
                             'data-building-card' => $definition->getKey(),
                         ],
-                        'body' => static function () use ($building, $production, $consumption, $requirements, $baseUrl,
-                                $resourceLabels, $icon): void {
+                        'body' => static function () use (
+                            $building,
+                            $production,
+                            $consumption,
+                            $requirements,
+                            $baseUrl,
+                            $resourceLabels,
+                            $icon,
+                            $requirementsPanel,
+                        ): void {
                             $bonuses = $building['bonuses'] ?? [];
                             echo '<div class="building-card__sections">';
                             echo '<div class="building-card__block">';

--- a/templates/research/index.php
+++ b/templates/research/index.php
@@ -95,7 +95,16 @@ ob_start();
                         'attributes' => [
                             'data-research-card' => $definition->getKey(),
                         ],
-                        'body' => static function () use ($definition, $item, $progress, $level, $maxLevel, $baseUrl, $icon): void {
+                        'body' => static function () use (
+                            $definition,
+                            $item,
+                            $progress,
+                            $level,
+                            $maxLevel,
+                            $baseUrl,
+                            $icon,
+                            $requirementsPanel,
+                        ): void {
 
                             echo '<p class="tech-card__description">' . htmlspecialchars($definition->getDescription()) . '</p>';
                             echo '<div class="tech-card__progress">';


### PR DESCRIPTION
## Summary
- ensure the requirements panel renderer is captured by the colony building card body closure
- expose the requirements panel helper to research card body closures to render missing prerequisites

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cf303ca4148332a4fa18d05cabaa21