### PR TITLE
Reorganize template structure and refresh documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Genesis Reborn
+
+Genesis Reborn est un jeu de stratégie spatial écrit en PHP 8.1 avec un front-end HTML/CSS/JS modulaire. Le dépôt suit PSR-12, propose des commentaires fonctionnels en français et s’appuie sur Composer et NPM pour automatiser les tâches quotidiennes.
+
+## Structure
+
+```
+config/           Configuration applicative et catalogues du jeu
+public/           Point d’entrée et assets compilés
+src/              Code métier (Application, Domain, Infrastructure, Controller)
+templates/
+  layouts/        Layout de base partagé
+  components/     Partials PHP réutilisables
+  pages/          Pages (auth, colony, dashboard, fleet, galaxy, journal, profile, research, shipyard, tech-tree)
+docs/             Documentation fonctionnelle détaillée
+migrations/       Scripts SQL pour la base
+```
+
+## Installation
+
+```bash
+composer install
+composer dump-autoload --optimize
+npm install
+```
+
+## Commandes utiles
+
+```bash
+# Qualité PHP
+composer test       # PHPUnit
+composer stan       # Analyse statique PHPStan
+composer cs         # Formatage PSR-12 via PHP-CS-Fixer
+
+# Front-end
+npm run lint        # ESLint + Stylelint
+npm run svgo:build  # Optimisation des SVG et génération du sprite
+```
+
+## Qualité & conventions
+
+- Code PHP formaté PSR-12 avec des commentaires explicatifs en français.
+- Toutes les pages front utilisent `templates/layouts/base.php` et les composants partagés.
+- Les assets inutilisés sont évités : n’ajoutez que des fichiers réellement référencés dans les catalogues ou les vues.
+- Pensez à exécuter les scripts Composer et NPM avant de pousser des modifications.
+
+## Documentation
+
+Le document `docs/README.md` détaille les mécaniques de jeu, les endpoints et la roadmap. Conservez-le à jour lors des évolutions majeures.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "scripts": {
         "test": "phpunit",
-        "cs": "php-cs-fixer fix --diff",
+        "cs": "./vendor/bin/php-cs-fixer fix --diff",
         "stan": "phpstan analyse src --level=5 --memory-limit=256M",
         "db:create": "php tools/db/create-database.php"
     },

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,10 @@
   /Domain (Entity, Service, ValueObjects)
   /Application (UseCase, Services Process*)
   /Infrastructure (HTTP, DB, Container, Security)
-/templates (layouts + pages)
+/templates
+  /layouts (base.php)
+  /components (*.php)
+  /pages (auth, colony, dashboard, fleet, galaxy, journal, profile, research, shipyard, tech-tree)
 tests (PHPUnit)
 ```
 

--- a/src/Controller/ColonyController.php
+++ b/src/Controller/ColonyController.php
@@ -43,7 +43,7 @@ class ColonyController extends AbstractController
         if (!$planets) {
             $this->addFlash('info', 'Aucune planète disponible.');
 
-            return $this->render('colony/index.php', [
+            return $this->render('pages/colony/index.php', [
                 'title' => 'Bâtiments',
                 'planets' => [],
                 'overview' => null,
@@ -127,7 +127,7 @@ class ColonyController extends AbstractController
             'resources' => $this->formatResourceSnapshot($planet),
         ];
 
-        return $this->render('colony/index.php', [
+        return $this->render('pages/colony/index.php', [
             'title' => 'Bâtiments',
             'planets' => $planets,
             'selectedPlanetId' => $selectedId,
@@ -141,10 +141,12 @@ class ColonyController extends AbstractController
             'activePlanetSummary' => $activePlanetSummary,
             'facilityStatuses' => $facilityStatuses,
         ]);
-}
+    }
 
     /**
      * @param array{jobs?: array<int, array<string, mixed>>} $queue
+     *
+     * Je transforme ici la file brute pour que la vue soit facile à lire.
      */
     private function formatBuildQueue(array $queue): array
     {
@@ -168,6 +170,8 @@ class ColonyController extends AbstractController
 
     /**
      * @param array<int, array{definition?: mixed}> $buildings
+     *
+     * Ce petit helper me permet de retrouver le bâtiment ciblé par sa clé.
      */
     private function findBuildingEntry(array $buildings, string $key): ?array
     {
@@ -187,6 +191,8 @@ class ColonyController extends AbstractController
 
     /**
      * @param array{definition: BuildingDefinition, level?: int, canUpgrade?: bool, cost?: array<string, int>, time?: int, production?: array<string, mixed>, consumption?: array<string, array<string, int>>, storage?: array<string, array<string, int>>, requirements?: array<string, mixed>} $entry
+     *
+     * Je normalise les infos du bâtiment pour que le front puisse les exploiter tranquille.
      */
     private function normalizeBuildingEntry(array $entry): array
     {

--- a/src/Controller/FleetController.php
+++ b/src/Controller/FleetController.php
@@ -46,7 +46,7 @@ class FleetController extends AbstractController
         if ($planets === []) {
             $this->addFlash('info', 'Aucune planète disponible.');
 
-            return $this->render('fleet/index.php', [
+            return $this->render('pages/fleet/index.php', [
                 'title' => 'Flotte',
                 'planets' => [],
                 'selectedPlanetId' => null,
@@ -111,7 +111,7 @@ class FleetController extends AbstractController
             try {
                 $definition = $this->shipCatalog->get($shipKey);
             } catch (InvalidArgumentException $exception) {
-                // Unknown ship in the catalogue – skip fancy data but keep counts.
+                // Je note ici que le vaisseau est inconnu, du coup je garde juste les infos minimales.
             }
 
             $label = $definition ? $definition->getLabel() : $shipKey;
@@ -158,6 +158,7 @@ class FleetController extends AbstractController
         usort($availableShips, static fn (array $a, array $b): int => strcmp($a['label'], $b['label']));
 
         $origin = $selectedPlanet->getCoordinates();
+        // Je prépare la destination par défaut avec les coordonnées actuelles.
         $submittedDestination = [
             'galaxy' => $origin['galaxy'],
             'system' => $origin['system'],
@@ -172,6 +173,7 @@ class FleetController extends AbstractController
             if (!$this->isCsrfTokenValid('fleet_plan_' . $selectedId, $data['csrf_token'] ?? null)) {
                 $planErrors[] = 'Session expirée, veuillez recharger la page.';
             } else {
+                // Je récupère les coordonnées visées dans le formulaire.
                 $destination = [
                     'galaxy' => max(1, (int) ($data['destination_galaxy'] ?? $origin['galaxy'])),
                     'system' => max(1, (int) ($data['destination_system'] ?? $origin['system'])),
@@ -244,7 +246,7 @@ class FleetController extends AbstractController
             ],
         ];
 
-        return $this->render('fleet/index.php', [
+        return $this->render('pages/fleet/index.php', [
             'title' => 'Flotte',
             'planets' => $planets,
             'selectedPlanetId' => $selectedId,

--- a/src/Controller/GalaxyController.php
+++ b/src/Controller/GalaxyController.php
@@ -59,7 +59,7 @@ class GalaxyController extends AbstractController
 
             $this->addFlash('info', 'Aucune planète disponible.');
 
-            return $this->render('galaxy/index.php', [
+            return $this->render('pages/galaxy/index.php', [
                 'title' => 'Carte galaxie',
                 'planets' => [],
                 'selectedPlanetId' => null,
@@ -115,7 +115,7 @@ class GalaxyController extends AbstractController
             ],
         ];
 
-        return $this->render('galaxy/index.php', [
+        return $this->render('pages/galaxy/index.php', [
             'title' => 'Carte galaxie',
             'planets' => $ownedPlanets,
             'selectedPlanetId' => $selectedId,
@@ -141,6 +141,8 @@ class GalaxyController extends AbstractController
 
     /**
      * @param Planet[] $planets
+     *
+     * Je balaie la liste pour retrouver la planète demandée.
      */
     private function findPlanet(array $planets, int $planetId): ?Planet
     {
@@ -156,6 +158,8 @@ class GalaxyController extends AbstractController
     /**
      * @param Planet[] $planets
      * @return array<int, array{id: int, name: string}>
+     *
+     * Ici je prépare un petit index des propriétaires pour l’affichage.
      */
     private function hydrateOwners(array $planets): array
     {
@@ -180,6 +184,8 @@ class GalaxyController extends AbstractController
      * @param Planet[] $systemPlanets
      * @param array<int, array{id: int, name: string}> $owners
      * @return array<int, array<string, mixed>>
+     *
+     * Je construis les 15 cases du système avec toutes les infos utiles.
      */
     private function buildSlots(
         array $systemPlanets,

--- a/src/Controller/JournalController.php
+++ b/src/Controller/JournalController.php
@@ -56,7 +56,7 @@ class JournalController extends AbstractController
         if ($planets === []) {
             $this->addFlash('info', 'Aucune planète disponible.');
 
-            return $this->render('journal/index.php', [
+            return $this->render('pages/journal/index.php', [
                 'title' => 'Journal de bord',
                 'planets' => [],
                 'selectedPlanetId' => null,
@@ -132,7 +132,7 @@ class JournalController extends AbstractController
             ],
         ];
 
-        return $this->render('journal/index.php', [
+        return $this->render('pages/journal/index.php', [
             'title' => 'Journal de bord',
             'planets' => $planets,
             'selectedPlanetId' => $selectedId,
@@ -156,6 +156,8 @@ class JournalController extends AbstractController
     /**
      * @param array<int, \App\Domain\Entity\BuildJob> $jobs
      * @return array<int, array<string, mixed>>
+     *
+     * Je transforme la file des constructions pour alimenter le journal.
      */
     private function mapBuildingEvents(array $jobs): array
     {
@@ -166,7 +168,7 @@ class JournalController extends AbstractController
                 $definition = $this->buildingCatalog->get($job->getBuildingKey());
                 $label = $definition->getLabel();
             } catch (InvalidArgumentException $exception) {
-                // unknown building: keep key as label.
+                // Ici je garde la clé brute si jamais la définition a disparu.
             }
 
             $events[] = $this->createEvent(
@@ -183,6 +185,8 @@ class JournalController extends AbstractController
     /**
      * @param array<int, \App\Domain\Entity\ResearchJob> $jobs
      * @return array<int, array<string, mixed>>
+     *
+     * Pareil ici, mais pour les recherches en cours.
      */
     private function mapResearchEvents(array $jobs): array
     {
@@ -193,7 +197,7 @@ class JournalController extends AbstractController
                 $definition = $this->researchCatalog->get($job->getResearchKey());
                 $label = $definition->getLabel();
             } catch (InvalidArgumentException $exception) {
-                // keep fallback label
+                // Ici aussi je garde la clé si le catalogue n’a pas la fiche.
             }
 
             $events[] = $this->createEvent(
@@ -210,6 +214,8 @@ class JournalController extends AbstractController
     /**
      * @param array<int, \App\Domain\Entity\ShipBuildJob> $jobs
      * @return array<int, array<string, mixed>>
+     *
+     * Même logique pour les chantiers navals afin d’avoir un suivi complet.
      */
     private function mapShipEvents(array $jobs): array
     {
@@ -220,7 +226,7 @@ class JournalController extends AbstractController
                 $definition = $this->shipCatalog->get($job->getShipKey());
                 $label = $definition->getLabel();
             } catch (InvalidArgumentException $exception) {
-                // keep fallback label
+                // Si je n’ai pas la définition, je conserve le nom technique pour debug.
             }
 
             $events[] = $this->createEvent(
@@ -236,6 +242,8 @@ class JournalController extends AbstractController
 
     /**
      * @return array{type: string, icon: string, title: string, description: string, endsAt: DateTimeImmutable, remaining: int}
+     *
+     * Je centralise ici le formatage d’un événement affiché dans l’UI.
      */
     private function createEvent(string $type, string $title, string $description, DateTimeImmutable $endsAt): array
     {

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -63,7 +63,7 @@ class ProfileController extends AbstractController
             ];
         }
 
-        return $this->render('profile/index.php', [
+        return $this->render('pages/profile/index.php', [
             'title' => 'Profil commandant',
             'account' => [
                 'email' => $user->getEmail(),

--- a/src/Controller/ResearchController.php
+++ b/src/Controller/ResearchController.php
@@ -43,7 +43,7 @@ class ResearchController extends AbstractController
         if (!$planets) {
             $this->addFlash('info', 'Aucune planète disponible.');
 
-            return $this->render('research/index.php', [
+            return $this->render('pages/research/index.php', [
                 'title' => 'Laboratoire de recherche',
                 'planets' => [],
                 'overview' => null,
@@ -143,7 +143,7 @@ class ResearchController extends AbstractController
             'resources' => $this->formatResourceSnapshot($planet),
         ];
 
-        return $this->render('research/index.php', [
+        return $this->render('pages/research/index.php', [
             'title' => 'Laboratoire de recherche',
             'planets' => $planets,
             'selectedPlanetId' => $selectedId,
@@ -157,10 +157,12 @@ class ResearchController extends AbstractController
             'activePlanetSummary' => $activePlanetSummary,
             'facilityStatuses' => $facilityStatuses,
         ]);
-}
+    }
 
     /**
      * @param array{jobs?: array<int, array<string, mixed>>} $queue
+     *
+     * Je prépare les jobs pour que le front affiche la file correctement.
      */
     private function formatResearchQueue(array $queue): array
     {
@@ -184,6 +186,8 @@ class ResearchController extends AbstractController
 
     /**
      * @param array<int, array{items?: array<int, array<string, mixed>>}> $categories
+     *
+     * Ce helper me sert à retrouver la fiche recherche demandée.
      */
     private function findResearchEntry(array $categories, string $key): ?array
     {
@@ -205,6 +209,8 @@ class ResearchController extends AbstractController
 
     /**
      * @param array{definition: ResearchDefinition, level?: int, maxLevel?: int, progress?: float, nextCost?: array<string, int>, nextTime?: int, requirements?: array<string, mixed>, canResearch?: bool} $entry
+     *
+     * Je nettoie la structure pour la réponse JSON lorsque l’action réussit.
      */
     private function normalizeResearchEntry(array $entry): array
     {

--- a/src/Controller/ShipyardController.php
+++ b/src/Controller/ShipyardController.php
@@ -43,7 +43,7 @@ class ShipyardController extends AbstractController
         if (!$planets) {
             $this->addFlash('info', 'Aucune planète disponible.');
 
-            return $this->render('shipyard/index.php', [
+            return $this->render('pages/shipyard/index.php', [
                 'title' => 'Chantier spatial',
                 'planets' => [],
                 'overview' => null,
@@ -145,7 +145,7 @@ class ShipyardController extends AbstractController
             'resources' => $this->formatResourceSnapshot($planet),
         ];
 
-        return $this->render('shipyard/index.php', [
+        return $this->render('pages/shipyard/index.php', [
             'title' => 'Chantier spatial',
             'planets' => $planets,
             'selectedPlanetId' => $selectedId,
@@ -159,10 +159,12 @@ class ShipyardController extends AbstractController
             'activePlanetSummary' => $activePlanetSummary,
             'facilityStatuses' => $facilityStatuses,
         ]);
-}
+    }
 
     /**
      * @param array{jobs?: array<int, array<string, mixed>>} $queue
+     *
+     * Je mets la file de production au propre pour les réponses JSON.
      */
     private function formatShipQueue(array $queue): array
     {
@@ -186,6 +188,8 @@ class ShipyardController extends AbstractController
 
     /**
      * @param array<int, array{items?: array<int, array<string, mixed>>}> $categories
+     *
+     * Ce helper me retrouve une entrée de vaisseau dans le catalogue préparé.
      */
     private function findShipEntry(array $categories, string $key): ?array
     {
@@ -207,6 +211,8 @@ class ShipyardController extends AbstractController
 
     /**
      * @param array{definition: ShipDefinition, requirements?: array<string, mixed>, canBuild?: bool} $entry
+     *
+     * Je renvoie un format simplifié pour le front après une création.
      */
     private function normalizeShipEntry(array $entry): array
     {

--- a/src/Domain/Entity/BuildingDefinition.php
+++ b/src/Domain/Entity/BuildingDefinition.php
@@ -29,7 +29,6 @@ class BuildingDefinition
         private readonly array $storage = [],
         private readonly array $upkeep = [],
         private readonly array $constructionSpeedBonus = []
-
     ) {
     }
 

--- a/src/Domain/Service/BuildingCatalog.php
+++ b/src/Domain/Service/BuildingCatalog.php
@@ -35,7 +35,6 @@ class BuildingCatalog
                 $data['storage'] ?? [],
                 $data['upkeep'] ?? [],
                 $data['construction_speed_bonus'] ?? []
-
             );
         }
     }

--- a/templates/pages/auth/login.php
+++ b/templates/pages/auth/login.php
@@ -1,8 +1,8 @@
 <?php
-/** @var string $csrf_token */
-/** @var string $baseUrl */
-/** @var array $flashes */
-/** @var int|null $currentUserId */
+/** @var string $csrf_token Jeton CSRF du formulaire de connexion. */
+/** @var string $baseUrl URL de base pour les liens. */
+/** @var array $flashes Messages flash à afficher. */
+/** @var int|null $currentUserId Identifiant utilisateur si connecté. */
 $title = $title ?? 'Connexion';
 ob_start();
 ?>

--- a/templates/pages/auth/register.php
+++ b/templates/pages/auth/register.php
@@ -1,8 +1,8 @@
 <?php
-/** @var string $csrf_token */
-/** @var string $baseUrl */
-/** @var array $flashes */
-/** @var int|null $currentUserId */
+/** @var string $csrf_token Jeton CSRF pour le formulaire d’inscription. */
+/** @var string $baseUrl URL de base pour les liens. */
+/** @var array $flashes Messages flash éventuels. */
+/** @var int|null $currentUserId Identifiant utilisateur si déjà connecté. */
 $title = $title ?? 'Inscription';
 ob_start();
 ?>

--- a/templates/pages/colony/index.php
+++ b/templates/pages/colony/index.php
@@ -1,20 +1,20 @@
-    <?php
-/** @var array<int, \App\Domain\Entity\Planet> $planets */
-/** @var array|null $overview */
-/** @var string $baseUrl */
-/** @var string|null $csrf_upgrade */
-/** @var int|null $selectedPlanetId */
-/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
+<?php
+/** @var array<int, \App\Domain\Entity\Planet> $planets Liste des planètes du joueur. */
+/** @var array|null $overview Données de la colonie courante. */
+/** @var string $baseUrl URL de base pour générer les liens. */
+/** @var string|null $csrf_upgrade Jeton CSRF pour l’amélioration. */
+/** @var int|null $selectedPlanetId Identifiant de la planète sélectionnée. */
+/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary Résumé de la planète pour l’en-tête. */
 
 $title = $title ?? 'Bâtiments';
 $planet = $overview['planet'] ?? null;
 $queue = $overview['queue'] ?? ['count' => 0, 'jobs' => []];
 $buildings = $overview['buildings'] ?? [];
 
-$icon = require __DIR__ . '/../components/_icon.php';
-$card = require __DIR__ . '/../components/_card.php';
-$requirementsPanel = require __DIR__ . '/../components/_requirements.php';
-require_once __DIR__ . '/../components/helpers.php';
+$icon = require __DIR__ . '/../../components/_icon.php';
+$card = require __DIR__ . '/../../components/_card.php';
+$requirementsPanel = require __DIR__ . '/../../components/_requirements.php';
+require_once __DIR__ . '/../../components/helpers.php';
 
 $resourceLabels = [
     'metal' => 'Métal',
@@ -321,4 +321,4 @@ ob_start();
 <?php endif; ?>
 <?php
 $content = ob_get_clean();
-require __DIR__ . '/../layouts/base.php';
+require __DIR__ . '/../../layouts/base.php';

--- a/templates/pages/dashboard/index.php
+++ b/templates/pages/dashboard/index.php
@@ -1,12 +1,12 @@
 <?php
-/** @var array $dashboard */
-/** @var string $baseUrl */
-/** @var array $flashes */
-/** @var int|null $currentUserId */
-/** @var string|null $csrf_logout */
-/** @var array<int, \App\Domain\Entity\Planet> $planets */
-/** @var int|null $selectedPlanetId */
-/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
+/** @var array $dashboard Résumé des données du joueur. */
+/** @var string $baseUrl URL de base pour les liens. */
+/** @var array $flashes Messages flash affichés. */
+/** @var int|null $currentUserId Identifiant de l’utilisateur connecté. */
+/** @var string|null $csrf_logout Jeton CSRF pour la déconnexion. */
+/** @var array<int, \App\Domain\Entity\Planet> $planets Liste des planètes. */
+/** @var int|null $selectedPlanetId Identifiant de la planète sélectionnée. */
+/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary Résumé de la planète pour le layout. */
 $title = $title ?? 'Vue d’ensemble';
 require_once __DIR__ . '/../../components/helpers.php';
 

--- a/templates/pages/fleet/index.php
+++ b/templates/pages/fleet/index.php
@@ -1,21 +1,21 @@
 <?php
-/** @var array<int, \App\Domain\Entity\Planet> $planets */
-/** @var array $fleetOverview */
-/** @var array<int, array{key: string, label: string, quantity: int, attack: int, defense: int, speed: int, category: string, role: string, image: ?string, fuelRate: int}> $availableShips */
-/** @var array $catalogCategories */
-/** @var array<string, int> $submittedComposition */
-/** @var array{galaxy: int, system: int, position: int} $submittedDestination */
-/** @var array|null $planResult */
-/** @var array<int, string> $planErrors */
-/** @var string $baseUrl */
-/** @var string|null $csrf_plan */
-/** @var int|null $selectedPlanetId */
-/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
+/** @var array<int, \App\Domain\Entity\Planet> $planets Liste des planètes disponibles. */
+/** @var array $fleetOverview Données agrégées de la flotte. */
+/** @var array<int, array{key: string, label: string, quantity: int, attack: int, defense: int, speed: int, category: string, role: string, image: ?string, fuelRate: int}> $availableShips Inventaire des vaisseaux prêts. */
+/** @var array $catalogCategories Catégories du catalogue de vaisseaux. */
+/** @var array<string, int> $submittedComposition Composition saisie dans le formulaire. */
+/** @var array{galaxy: int, system: int, position: int} $submittedDestination Cible choisie par le joueur. */
+/** @var array|null $planResult Résultat éventuel du calcul de trajet. */
+/** @var array<int, string> $planErrors Liste des erreurs rencontrées. */
+/** @var string $baseUrl URL de base pour les liens. */
+/** @var string|null $csrf_plan Jeton CSRF du planificateur. */
+/** @var int|null $selectedPlanetId Identifiant de la planète active. */
+/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary Résumé pour l’entête de page. */
 
 $title = $title ?? 'Flotte';
-$icon = require __DIR__ . '/../components/_icon.php';
-$card = require __DIR__ . '/../components/_card.php';
-require_once __DIR__ . '/../components/helpers.php';
+$icon = require __DIR__ . '/../../components/_icon.php';
+$card = require __DIR__ . '/../../components/_card.php';
+require_once __DIR__ . '/../../components/helpers.php';
 
 $fleetShips = $fleetOverview['ships'] ?? [];
 $totalShips = $fleetOverview['totalShips'] ?? 0;
@@ -148,4 +148,4 @@ ob_start();
 </div>
 <?php
 $content = ob_get_clean();
-require __DIR__ . '/../layouts/base.php';
+require __DIR__ . '/../../layouts/base.php';

--- a/templates/pages/galaxy/index.php
+++ b/templates/pages/galaxy/index.php
@@ -1,16 +1,16 @@
 <?php
-/** @var array<int, \App\Domain\Entity\Planet> $planets */
-/** @var array<int, array<string, mixed>> $slots */
-/** @var array<string, mixed> $summary */
-/** @var array<int, array<string, mixed>> $players */
-/** @var array<string, mixed> $filters */
-/** @var string $baseUrl */
-/** @var int|null $selectedPlanetId */
-/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
+/** @var array<int, \App\Domain\Entity\Planet> $planets Planètes contrôlées par le joueur. */
+/** @var array<int, array<string, mixed>> $slots Cases construites pour la vue galaxie. */
+/** @var array<string, mixed> $summary Synthèse des informations du système. */
+/** @var array<int, array<string, mixed>> $players Classement des propriétaires. */
+/** @var array<string, mixed> $filters Filtres utilisés dans le formulaire. */
+/** @var string $baseUrl URL de base pour les liens. */
+/** @var int|null $selectedPlanetId Identifiant de la planète mise en avant. */
+/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary Résumé de la planète affichée. */
 
 $title = $title ?? 'Carte galaxie';
-$card = require __DIR__ . '/../components/_card.php';
-require_once __DIR__ . '/../components/helpers.php';
+$card = require __DIR__ . '/../../components/_card.php';
+require_once __DIR__ . '/../../components/helpers.php';
 
 $spriteIcon = static fn (string $name): string => asset_url('assets/svg/sprite.svg#icon-' . $name, $baseUrl ?? '');
 
@@ -212,4 +212,4 @@ ob_start();
 ]) ?>
 <?php
 $content = ob_get_clean();
-require __DIR__ . '/../layouts/base.php';
+require __DIR__ . '/../../layouts/base.php';

--- a/templates/pages/journal/index.php
+++ b/templates/pages/journal/index.php
@@ -1,14 +1,14 @@
 <?php
-/** @var array<int, \App\Domain\Entity\Planet> $planets */
-/** @var array<int, array{type: string, icon: string, title: string, description: string, endsAt: \DateTimeImmutable, remaining: int}> $events */
-/** @var array{buildQueue: int, researchQueue: int, shipQueue: int, nextEvent: ?array} $insights */
-/** @var string $baseUrl */
-/** @var int|null $selectedPlanetId */
-/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
+/** @var array<int, \App\Domain\Entity\Planet> $planets Planètes accessibles pour la sélection. */
+/** @var array<int, array{type: string, icon: string, title: string, description: string, endsAt: \DateTimeImmutable, remaining: int}> $events Evénements structurés pour l’affichage. */
+/** @var array{buildQueue: int, researchQueue: int, shipQueue: int, nextEvent: ?array} $insights Compteurs synthétiques affichés dans la vue. */
+/** @var string $baseUrl URL de base pour générer les liens. */
+/** @var int|null $selectedPlanetId Identifiant de la planète suivie. */
+/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary Résumé de la planète affichée. */
 
 $title = $title ?? 'Journal de bord';
-$icon = require __DIR__ . '/../components/_icon.php';
-$card = require __DIR__ . '/../components/_card.php';
+$icon = require __DIR__ . '/../../components/_icon.php';
+$card = require __DIR__ . '/../../components/_card.php';
 
 ob_start();
 ?>
@@ -63,4 +63,4 @@ ob_start();
 ]) ?>
 <?php
 $content = ob_get_clean();
-require __DIR__ . '/../layouts/base.php';
+require __DIR__ . '/../../layouts/base.php';

--- a/templates/pages/profile/index.php
+++ b/templates/pages/profile/index.php
@@ -1,15 +1,15 @@
 <?php
-/** @var array{email: string, username: string} $account */
-/** @var array<int, \App\Domain\Entity\Planet> $planets */
-/** @var array $dashboard */
-/** @var string $baseUrl */
-/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
+/** @var array{email: string, username: string} $account Infos de mon profil. */
+/** @var array<int, \App\Domain\Entity\Planet> $planets Liste de mes planètes. */
+/** @var array $dashboard Données consolidées du tableau de bord. */
+/** @var string $baseUrl URL de base pour les liens. */
+/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary Résumé de la planète affichée. */
 
 $title = $title ?? 'Profil commandant';
-$icon = require __DIR__ . '/../components/_icon.php';
-$resourceBar = require __DIR__ . '/../components/_resource_bar.php';
-$card = require __DIR__ . '/../components/_card.php';
-require_once __DIR__ . '/../components/helpers.php';
+$icon = require __DIR__ . '/../../components/_icon.php';
+$resourceBar = require __DIR__ . '/../../components/_resource_bar.php';
+$card = require __DIR__ . '/../../components/_card.php';
+require_once __DIR__ . '/../../components/helpers.php';
 $planets = $planets ?? [];
 
 $dashboard = $dashboard ?? [];
@@ -169,4 +169,4 @@ ob_start();
 <?php endif; ?>
 <?php
 $content = ob_get_clean();
-require __DIR__ . '/../layouts/base.php';
+require __DIR__ . '/../../layouts/base.php';

--- a/templates/pages/research/index.php
+++ b/templates/pages/research/index.php
@@ -1,16 +1,16 @@
 <?php
-/** @var array<int, \App\Domain\Entity\Planet> $planets */
-/** @var array|null $overview */
-/** @var string $baseUrl */
-/** @var string|null $csrf_start */
-/** @var int|null $selectedPlanetId */
-/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
+/** @var array<int, \App\Domain\Entity\Planet> $planets Planètes du joueur. */
+/** @var array|null $overview Détails du laboratoire actif. */
+/** @var string $baseUrl URL de base pour générer les liens. */
+/** @var string|null $csrf_start Jeton CSRF pour lancer une recherche. */
+/** @var int|null $selectedPlanetId Identifiant de la planète affichée. */
+/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary Résumé de ressources utilisé par le layout. */
 
 $title = $title ?? 'Laboratoire de recherche';
-$icon = require __DIR__ . '/../components/_icon.php';
-$card = require __DIR__ . '/../components/_card.php';
-$requirementsPanel = require __DIR__ . '/../components/_requirements.php';
-require_once __DIR__ . '/../components/helpers.php';
+$icon = require __DIR__ . '/../../components/_icon.php';
+$card = require __DIR__ . '/../../components/_card.php';
+$requirementsPanel = require __DIR__ . '/../../components/_requirements.php';
+require_once __DIR__ . '/../../components/helpers.php';
 
 $overview = $overview ?? null;
 $queue = $overview['queue'] ?? ['count' => 0, 'jobs' => []];
@@ -166,4 +166,4 @@ ob_start();
 <?php endif; ?>
 <?php
 $content = ob_get_clean();
-require __DIR__ . '/../layouts/base.php';
+require __DIR__ . '/../../layouts/base.php';

--- a/templates/pages/shipyard/index.php
+++ b/templates/pages/shipyard/index.php
@@ -1,15 +1,15 @@
 <?php
-/** @var array<int, \App\Domain\Entity\Planet> $planets */
-/** @var array|null $overview */
-/** @var string $baseUrl */
-/** @var string|null $csrf_shipyard */
-/** @var int|null $selectedPlanetId */
-/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary */
+/** @var array<int, \App\Domain\Entity\Planet> $planets Planètes gérées par le joueur. */
+/** @var array|null $overview Détails du chantier actif. */
+/** @var string $baseUrl URL de base pour les actions. */
+/** @var string|null $csrf_shipyard Jeton CSRF pour la production. */
+/** @var int|null $selectedPlanetId Identifiant de la planète ciblée. */
+/** @var array{planet: \App\Domain\Entity\Planet, resources: array<string, array{value: int, perHour: int}>}|null $activePlanetSummary Résumé de la planète sélectionnée. */
 
 $title = $title ?? 'Chantier spatial';
-$icon = require __DIR__ . '/../components/_icon.php';
-$card = require __DIR__ . '/../components/_card.php';
-require_once __DIR__ . '/../components/helpers.php';
+$icon = require __DIR__ . '/../../components/_icon.php';
+$card = require __DIR__ . '/../../components/_card.php';
+require_once __DIR__ . '/../../components/helpers.php';
 
 $overview = $overview ?? null;
 $queue = $overview['queue'] ?? ['count' => 0, 'jobs' => []];
@@ -158,4 +158,4 @@ ob_start();
 <?php endif; ?>
 <?php
 $content = ob_get_clean();
-require __DIR__ . '/../layouts/base.php';
+require __DIR__ . '/../../layouts/base.php';

--- a/templates/pages/tech-tree/index.php
+++ b/templates/pages/tech-tree/index.php
@@ -1,8 +1,8 @@
 <?php
-/** @var array<int, \App\Domain\Entity\Planet> $planets */
-/** @var array $tree */
-/** @var string $baseUrl */
-/** @var int|null $selectedPlanetId */
+/** @var array<int, \App\Domain\Entity\Planet> $planets Liste des planètes. */
+/** @var array $tree Données de l’arbre technologique. */
+/** @var string $baseUrl URL de base pour les liens. */
+/** @var int|null $selectedPlanetId Identifiant de la planète choisie. */
 $title = $title ?? 'Arbre technologique';
 $categories = $tree['categories'] ?? [];
 $nodes = [];


### PR DESCRIPTION
## Summary
- move all page templates under `templates/pages` and update controllers plus includes so every page shares the same layout/components
- add French inline comments in controllers and templates, refresh docs/README architecture section, and introduce a root README with structure and workflows
- point the `composer cs` script to the project binary to keep PSR-12 enforcement accessible

## Testing
- composer cs
- composer test
- composer stan *(fails: existing PHPStan level 5 findings about array offsets and docblocks)*
- npm run lint
- npm run svgo:build

------
https://chatgpt.com/codex/tasks/task_e_68cf32137ad083329fcb64d7d424d49e