### PR TITLE
Moderniser la page chantier spatial et replier les prérequis

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -1868,13 +1868,6 @@ main.workspace__content {
 }
 
 .ship-card {
-    background: rgba(255, 255, 255, 0.04);
-    border-radius: var(--radius);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    padding: var(--space-5);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-4);
     height: 100%;
 }
 
@@ -1882,16 +1875,22 @@ main.workspace__content {
     opacity: 0.65;
 }
 
-.ship-card__header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+.ship-card .panel__header {
+    align-items: flex-start;
+    gap: var(--space-3);
+}
+
+.ship-card .panel__body {
+    flex: 1;
     gap: var(--space-4);
 }
 
-.ship-card__role {
+.ship-card .panel__footer {
+    margin-top: auto;
+}
+
+.ship-card__description {
     margin: 0;
-    font-size: var(--font-size-sm);
     color: var(--color-muted);
 }
 
@@ -1926,12 +1925,10 @@ main.workspace__content {
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.ship-card__requirements ul {
-    margin: 0;
-    padding-left: 1.2rem;
-    color: var(--color-muted);
-    display: grid;
-    gap: var(--space-1);
+.ship-card__section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
 }
 
 .ship-card__footer form {

--- a/public/assets/js/__tests__/card-updates.test.js
+++ b/public/assets/js/__tests__/card-updates.test.js
@@ -185,9 +185,11 @@ test('updateResearchCard syncs progress, costs and availability', () => {
 
 test('updateShipCard toggles availability and requirements', () => {
     document.body.innerHTML = `
-        <article class="ship-card is-locked" data-ship-card="fighter">
-            <div class="ship-card__content"></div>
-            <footer class="ship-card__footer">
+        <article class="panel ship-card is-locked" data-ship-card="fighter">
+            <div class="panel__body ship-card__body">
+                <div class="ship-card__content"></div>
+            </div>
+            <footer class="panel__footer ship-card__footer">
                 <form data-async="queue">
                     <label class="ship-card__quantity"><span>Quantité</span><input type="number" name="quantity" value="1" disabled></label>
                     <button type="submit" class="button button--primary" disabled>Pré-requis manquants</button>

--- a/templates/pages/colony/index.php
+++ b/templates/pages/colony/index.php
@@ -292,7 +292,6 @@ ob_start();
                                             'baseUrl' => $baseUrl,
                                             'class' => 'icon-sm requirements-panel__glyph',
                                         ]),
-                                        'open' => true,
                                     ]);
                                     echo '</div>';
                                 }

--- a/templates/pages/research/index.php
+++ b/templates/pages/research/index.php
@@ -143,7 +143,6 @@ ob_start();
                                             'baseUrl' => $baseUrl,
                                             'class' => 'icon-sm requirements-panel__glyph',
                                         ]),
-                                        'open' => true,
                                     ]);
                                     echo '</div>';
                                 }


### PR DESCRIPTION
## Résumé
- refonte de la page chantier spatial en utilisant les cartes standard avec coûts, statistiques et prérequis repliables
- factorisation JS pour rendre un panneau de prérequis commun et replié par défaut sur les bâtiments, recherches et vaisseaux
- mise à jour des styles et des tests associés pour la nouvelle structure des cartes de vaisseaux

## Tests
- npm run lint:js
- npm run lint:css
- node --test public/assets/js/__tests__/card-updates.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf381de2588332a24c9c621aec5988