### PR TITLE
Prevent storage capacity from compounding across ticks

### DIFF
--- a/src/Domain/Service/ResourceTickService.php
+++ b/src/Domain/Service/ResourceTickService.php
@@ -27,6 +27,7 @@ class ResourceTickService
      *     player_id?: int,
      *     resources: array<string, int|float>,
      *     capacities: array<string, int|float>,
+     *     base_capacities?: array<string, int|float>,
      *     last_tick?: DateTimeInterface,
      *     building_levels: array<string, int>,
      * }> $planetStates
@@ -59,8 +60,25 @@ class ResourceTickService
                 $resourceTotals[$resourceKey] = (float) $value;
             }
 
-            $capacityTotals = [];
+            $baseCapacities = [];
+            if (isset($state['base_capacities']) && is_array($state['base_capacities'])) {
+                foreach ($state['base_capacities'] as $resourceKey => $value) {
+                    $baseCapacities[$resourceKey] = (float) $value;
+                }
+            }
+
+            $capacityTotals = $baseCapacities;
             foreach ($state['capacities'] as $resourceKey => $value) {
+                if (!array_key_exists($resourceKey, $capacityTotals)) {
+                    $capacityTotals[$resourceKey] = (float) $value;
+                    continue;
+                }
+
+                // When base capacities are provided explicitly, rebuild totals from that base.
+                if ($baseCapacities !== []) {
+                    continue;
+                }
+
                 $capacityTotals[$resourceKey] = (float) $value;
             }
 


### PR DESCRIPTION
## Summary
- rebuild `ResourceTickService` capacity totals from optional `base_capacities` before adding storage effects
- update and extend unit coverage to pass base capacities and assert storage capacity stays stable across sequential ticks

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cf3a4ef09c8332af19ae6788bc9fec