### PR TITLE
Fix storage capacity accumulation

### DIFF
--- a/src/Controller/ResourceApiController.php
+++ b/src/Controller/ResourceApiController.php
@@ -60,6 +60,8 @@ class ResourceApiController extends AbstractController
             ], 404);
         }
 
+        $previousBuildingLevels = $this->buildingStates->getLevels($planetId);
+
         $this->buildQueue->process($planetId);
         $this->researchQueue->process($planetId);
         $this->shipQueue->process($planetId);
@@ -96,6 +98,7 @@ class ResourceApiController extends AbstractController
                 ],
                 'last_tick' => $lastTick,
                 'building_levels' => $buildingLevels,
+                'previous_building_levels' => $previousBuildingLevels,
             ],
         ];
 

--- a/src/Domain/Service/ResourceTickService.php
+++ b/src/Domain/Service/ResourceTickService.php
@@ -30,6 +30,7 @@ class ResourceTickService
      *     base_capacities?: array<string, int|float>,
      *     last_tick?: DateTimeInterface,
      *     building_levels: array<string, int>,
+     *     previous_building_levels?: array<string, int>,
      * }> $planetStates
      * @param DateTimeInterface $now
      * @param array<string, array<string, mixed>>|null $effectsOverride
@@ -68,28 +69,43 @@ class ResourceTickService
             }
 
             $capacityTotals = $baseCapacities;
+            $currentCapacities = [];
             foreach ($state['capacities'] as $resourceKey => $value) {
+                $currentCapacities[$resourceKey] = (float) $value;
+
                 if (!array_key_exists($resourceKey, $capacityTotals)) {
                     $capacityTotals[$resourceKey] = (float) $value;
-                    continue;
                 }
+            }
 
-                // When base capacities are provided explicitly, rebuild totals from that base.
-                if ($baseCapacities !== []) {
-                    continue;
+            $buildingLevels = [];
+            if (isset($state['building_levels']) && is_array($state['building_levels'])) {
+                foreach ($state['building_levels'] as $buildingKey => $level) {
+                    $buildingLevels[$buildingKey] = max(0, (int) $level);
                 }
+            }
 
-                $capacityTotals[$resourceKey] = (float) $value;
+            $previousBuildingLevels = [];
+            if (isset($state['previous_building_levels']) && is_array($state['previous_building_levels'])) {
+                foreach ($state['previous_building_levels'] as $buildingKey => $level) {
+                    $previousBuildingLevels[$buildingKey] = max(0, (int) $level);
+                }
             }
 
             $productionRaw = [];
             $energyProduction = 0.0;
             $energyConsumption = 0.0;
 
-            foreach ($state['building_levels'] as $buildingKey => $level) {
-                if ($level <= 0) {
-                    continue;
-                }
+            $allBuildingKeys = array_unique(array_merge(
+                array_keys($buildingLevels),
+                array_keys($previousBuildingLevels)
+            ));
+
+            $baseCapacitiesProvided = $baseCapacities !== [];
+
+            foreach ($allBuildingKeys as $buildingKey) {
+                $level = $buildingLevels[$buildingKey] ?? 0;
+                $previousLevel = $previousBuildingLevels[$buildingKey] ?? $level;
 
                 $effect = $effects[$buildingKey] ?? null;
                 if ($effect === null) {
@@ -98,9 +114,25 @@ class ResourceTickService
 
                 if (isset($effect['storage']) && is_array($effect['storage'])) {
                     foreach ($effect['storage'] as $resourceKey => $config) {
-                        $capacityTotals[$resourceKey] = ($capacityTotals[$resourceKey] ?? 0.0)
-                            + $this->valueForLevel($config, $level);
+                        $currentValue = $this->valueForLevel($config, $level);
+
+                        if ($baseCapacitiesProvided) {
+                            $capacityTotals[$resourceKey] = ($capacityTotals[$resourceKey] ?? 0.0) + $currentValue;
+                            continue;
+                        }
+
+                        $previousValue = $this->valueForLevel($config, $previousLevel);
+                        $currentTotal = ($capacityTotals[$resourceKey] ?? 0.0) - $previousValue;
+                        if ($currentTotal < 0.0) {
+                            $currentTotal = 0.0;
+                        }
+
+                        $capacityTotals[$resourceKey] = $currentTotal + $currentValue;
                     }
+                }
+
+                if ($level <= 0) {
+                    continue;
                 }
 
                 if (isset($effect['produces']) && is_array($effect['produces'])) {

--- a/tests/Unit/ResourceTickServiceTest.php
+++ b/tests/Unit/ResourceTickServiceTest.php
@@ -229,4 +229,90 @@ class ResourceTickServiceTest extends TestCase
         self::assertSame($firstPlanetTick['capacities']['hydrogen'], $secondPlanetTick['capacities']['hydrogen']);
         self::assertSame($firstPlanetTick['capacities']['energy'], $secondPlanetTick['capacities']['energy']);
     }
+
+    public function testStorageCapacityDoesNotAccumulateWithoutExplicitBase(): void
+    {
+        $effects = [
+            'storage_depot' => [
+                'storage' => [
+                    'metal' => ['base' => 5000, 'growth' => 1.5],
+                    'crystal' => ['base' => 2500, 'growth' => 1.4],
+                    'hydrogen' => ['base' => 2000, 'growth' => 1.3],
+                    'energy' => ['base' => 50, 'growth' => 1.1],
+                ],
+            ],
+        ];
+
+        $service = new ResourceTickService($effects);
+
+        $startTick = new DateTimeImmutable('2025-09-20 08:00:00');
+        $firstTickTime = $startTick->add(new DateInterval('PT1H'));
+
+        $initialCapacities = [
+            'metal' => 17500,
+            'crystal' => 11500,
+            'hydrogen' => 8600,
+            'energy' => 155,
+        ];
+
+        $initialState = [
+            'planet_id' => 1,
+            'player_id' => 10,
+            'resources' => [
+                'metal' => 2000,
+                'crystal' => 1000,
+                'hydrogen' => 500,
+                'energy' => 0,
+            ],
+            'capacities' => $initialCapacities,
+            'last_tick' => $startTick,
+            'building_levels' => [
+                'storage_depot' => 2,
+            ],
+            'previous_building_levels' => [
+                'storage_depot' => 2,
+            ],
+        ];
+
+        $firstTick = $service->tick([1 => $initialState], $firstTickTime);
+        $firstPlanetTick = $firstTick[1];
+
+        self::assertSame($initialCapacities['metal'], $firstPlanetTick['capacities']['metal']);
+        self::assertSame($initialCapacities['crystal'], $firstPlanetTick['capacities']['crystal']);
+        self::assertSame($initialCapacities['hydrogen'], $firstPlanetTick['capacities']['hydrogen']);
+        self::assertSame($initialCapacities['energy'], $firstPlanetTick['capacities']['energy']);
+
+        $secondState = $initialState;
+        $secondState['last_tick'] = $firstTickTime;
+        $secondState['resources'] = $firstPlanetTick['resources'];
+        $secondState['capacities'] = $firstPlanetTick['capacities'];
+        $secondState['previous_building_levels'] = $initialState['building_levels'];
+
+        $secondTickTime = $firstTickTime->add(new DateInterval('PT1H'));
+        $secondTick = $service->tick([1 => $secondState], $secondTickTime);
+        $secondPlanetTick = $secondTick[1];
+
+        self::assertSame($firstPlanetTick['capacities']['metal'], $secondPlanetTick['capacities']['metal']);
+        self::assertSame($firstPlanetTick['capacities']['crystal'], $secondPlanetTick['capacities']['crystal']);
+        self::assertSame($firstPlanetTick['capacities']['hydrogen'], $secondPlanetTick['capacities']['hydrogen']);
+        self::assertSame($firstPlanetTick['capacities']['energy'], $secondPlanetTick['capacities']['energy']);
+
+        $upgradeState = $secondState;
+        $upgradeState['last_tick'] = $secondTickTime;
+        $upgradeState['resources'] = $secondPlanetTick['resources'];
+        $upgradeState['capacities'] = $secondPlanetTick['capacities'];
+        $upgradeState['previous_building_levels'] = $secondState['building_levels'];
+        $upgradeState['building_levels'] = [
+            'storage_depot' => 3,
+        ];
+
+        $upgradeTickTime = $secondTickTime->add(new DateInterval('PT1H'));
+        $upgradeTick = $service->tick([1 => $upgradeState], $upgradeTickTime);
+        $upgradePlanetTick = $upgradeTick[1];
+
+        self::assertSame(21250, $upgradePlanetTick['capacities']['metal']);
+        self::assertSame(12900, $upgradePlanetTick['capacities']['crystal']);
+        self::assertSame(9380, $upgradePlanetTick['capacities']['hydrogen']);
+        self::assertSame(161, $upgradePlanetTick['capacities']['energy']);
+    }
 }


### PR DESCRIPTION
## Summary
- adjust the resource tick to recompute storage capacity from previous building levels so totals stay stable
- expose previous building levels from the resource API controller to feed the tick service
- cover the regression with unit tests that validate stability and upgrades without explicit base capacities

## Testing
- composer test *(fails: phpunit binary is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3e08ed8c83328ec4cf6f0d6f21fd