### PR TITLE
feat: enhance research lab overview

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -1247,6 +1247,11 @@ main.workspace__content {
     height: 100%;
 }
 
+.tech-card .panel__header {
+    align-items: flex-start;
+    gap: var(--space-3);
+}
+
 .tech-card .panel__body {
     flex: 1;
     gap: var(--space-3);

--- a/src/Application/UseCase/Research/GetResearchOverview.php
+++ b/src/Application/UseCase/Research/GetResearchOverview.php
@@ -28,6 +28,8 @@ class GetResearchOverview
      * @return array{
      *     planet: \App\Domain\Entity\Planet,
      *     labLevel: int,
+     *     labBonus: float,
+     *     buildingLevels: array<string, int>,
      *     researchLevels: array<string, int>,
      *     queue: array{count: int, jobs: array<int, array{research: string, label: string, targetLevel: int, endsAt: \DateTimeImmutable, remaining: int}>},
      *     categories: array<int, array{label: string, image: string, items: array<int, array<string, mixed>>}>,
@@ -46,6 +48,7 @@ class GetResearchOverview
         $buildingLevels = $this->buildingStates->getLevels($planetId);
         $researchLevels = $this->researchStates->getLevels($planetId);
         $labLevel = $buildingLevels['research_lab'] ?? 0;
+        $labBonus = $this->calculator->labSpeedBonus($labLevel);
 
         $catalogMap = [];
         foreach ($this->catalog->all() as $definition) {
@@ -122,6 +125,7 @@ class GetResearchOverview
         return [
             'planet' => $planet,
             'labLevel' => $labLevel,
+            'labBonus' => $labBonus,
             'researchLevels' => $researchLevels,
             'buildingLevels' => $buildingLevels,
             'queue' => [

--- a/src/Domain/Service/ResearchCalculator.php
+++ b/src/Domain/Service/ResearchCalculator.php
@@ -37,6 +37,18 @@ class ResearchCalculator
         return max(1, (int) round($baseDuration));
     }
 
+    public function labSpeedBonus(int $labLevel): float
+    {
+        $effectiveLabLevel = max(0, $labLevel);
+        $bonusPerLevel = max(0.0, $this->labSpeedBonusPerLevel);
+
+        if ($effectiveLabLevel === 0 || $bonusPerLevel <= 0.0) {
+            return 0.0;
+        }
+
+        return $effectiveLabLevel * $bonusPerLevel;
+    }
+
     /**
      * @param array<string, int> $researchLevels
      * @param array<string, array{label: string}> $researchCatalog

--- a/templates/pages/research/index.php
+++ b/templates/pages/research/index.php
@@ -15,6 +15,8 @@ require_once __DIR__ . '/../../components/helpers.php';
 $overview = $overview ?? null;
 $queue = $overview['queue'] ?? ['count' => 0, 'jobs' => []];
 $categories = $overview['categories'] ?? [];
+$labLevel = (int) ($overview['labLevel'] ?? 0);
+$labBonus = (float) ($overview['labBonus'] ?? 0.0);
 $assetBase = rtrim($baseUrl, '/');
 
 ob_start();
@@ -46,8 +48,14 @@ ob_start();
     <?= $card([
         'title' => 'Recherches en cours',
         'subtitle' => 'Suivi des programmes scientifiques actifs',
-        'body' => static function () use ($queue): void {
+        'body' => static function () use ($queue, $labLevel, $labBonus): void {
             $emptyMessage = 'Aucune recherche n’est en cours. Lancez une étude pour étendre vos connaissances.';
+            echo '<p class="metric-line"><span class="metric-line__label">Niveau du laboratoire</span><span class="metric-line__value">' . number_format($labLevel) . '</span></p>';
+            if ($labBonus > 0) {
+                $bonusPercent = $labBonus * 100;
+                $bonusDisplay = rtrim(rtrim(number_format($bonusPercent, 1), '0'), '.');
+                echo '<p class="metric-line"><span class="metric-line__label">Bonus de vitesse</span><span class="metric-line__value metric-line__value--positive">+' . htmlspecialchars($bonusDisplay) . ' %</span></p>';
+            }
             echo '<div class="queue-block" data-queue="research" data-empty="' . htmlspecialchars($emptyMessage, ENT_QUOTES) . '">';
             if (($queue['count'] ?? 0) === 0) {
                 echo '<p class="empty-state">' . htmlspecialchars($emptyMessage) . '</p>';
@@ -86,6 +94,7 @@ ob_start();
                     $maxLevel = (int) ($item['maxLevel'] ?? 0);
                     $progress = (int) round(($item['progress'] ?? 0) * 100);
                     $status = $canResearch ? '' : 'is-locked';
+                    $imagePath = $definition->getImage();
                     ?>
                     <?= $card([
                         'title' => $definition->getLabel(),
@@ -95,6 +104,7 @@ ob_start();
                         'attributes' => [
                             'data-research-card' => $definition->getKey(),
                         ],
+                        'illustration' => $imagePath ? $assetBase . '/' . ltrim($imagePath, '/') : null,
                         'body' => static function () use (
                             $definition,
                             $item,


### PR DESCRIPTION
## Summary
- surface the research lab level and its speed bonus in the active research queue card
- display the research artwork on technology cards and align their headers with illustrations
- expose the lab speed bonus from the research calculator for reuse in the overview

## Testing
- composer test *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3ef75c108332901384a6fff7fcf7