### PR TITLE
Fix research lab speed bonus scaling

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -106,9 +106,28 @@ return function (Container $container): void {
 
     $container->set(ResearchCalculator::class, function () {
         $config = require __DIR__ . '/game/buildings.php';
-        $bonus = (float) ($config['research_lab']['research_speed_bonus'] ?? 0.0);
+        $bonusConfig = $config['research_lab']['research_speed_bonus'] ?? 0.0;
+        $bonusPerLevel = 0.0;
+        $bonusMax = 0.0;
 
-        return new ResearchCalculator($bonus);
+        if (is_array($bonusConfig)) {
+            if (array_key_exists('per_level', $bonusConfig)) {
+                $bonusPerLevel = (float) $bonusConfig['per_level'];
+            } else {
+                $bonusPerLevel = (float) ($bonusConfig['base'] ?? 0.0);
+            }
+
+            if (array_key_exists('max', $bonusConfig)) {
+                $bonusMax = (float) $bonusConfig['max'];
+            }
+        } else {
+            $bonusPerLevel = (float) $bonusConfig;
+        }
+
+        $bonusPerLevel = max(0.0, $bonusPerLevel);
+        $bonusMax = max(0.0, $bonusMax);
+
+        return new ResearchCalculator($bonusPerLevel, $bonusMax);
     });
 
     $container->set(ShipCatalog::class, function () {

--- a/src/Domain/Service/ResearchCalculator.php
+++ b/src/Domain/Service/ResearchCalculator.php
@@ -6,8 +6,10 @@ use App\Domain\Entity\ResearchDefinition;
 
 class ResearchCalculator
 {
-    public function __construct(private readonly float $labSpeedBonusPerLevel = 0.0)
-    {
+    public function __construct(
+        private readonly float $labSpeedBonusPerLevel = 0.0,
+        private readonly float $labSpeedBonusMax = 0.0
+    ) {
     }
 
     /**
@@ -26,9 +28,8 @@ class ResearchCalculator
     public function nextTime(ResearchDefinition $definition, int $currentLevel, int $labLevel): int
     {
         $baseDuration = (float) $definition->getBaseTime() * pow($definition->getGrowthTime(), $currentLevel);
-        $effectiveLabLevel = max(0, $labLevel);
-        $bonusPerLevel = max(0.0, $this->labSpeedBonusPerLevel);
-        $speedMultiplier = 1.0 + ($effectiveLabLevel * $bonusPerLevel);
+        $bonus = $this->labSpeedBonus($labLevel);
+        $speedMultiplier = 1.0 + $bonus;
 
         if ($speedMultiplier > 0.0) {
             $baseDuration /= $speedMultiplier;
@@ -46,7 +47,13 @@ class ResearchCalculator
             return 0.0;
         }
 
-        return $effectiveLabLevel * $bonusPerLevel;
+        $bonus = $effectiveLabLevel * $bonusPerLevel;
+
+        if ($this->labSpeedBonusMax > 0.0) {
+            $bonus = min($bonus, max(0.0, $this->labSpeedBonusMax));
+        }
+
+        return $bonus;
     }
 
     /**

--- a/tests/Unit/ResearchCalculatorTest.php
+++ b/tests/Unit/ResearchCalculatorTest.php
@@ -111,4 +111,12 @@ class ResearchCalculatorTest extends TestCase
 
         self::assertSame(1, $shortDuration);
     }
+
+    public function testLabSpeedBonusRespectsConfiguredMaximum(): void
+    {
+        $cappedCalculator = new ResearchCalculator(0.5, 0.75);
+
+        self::assertSame(0.75, $cappedCalculator->labSpeedBonus(5));
+        self::assertSame(69, $cappedCalculator->nextTime($this->definition, 0, 5));
+    }
 }


### PR DESCRIPTION
## Summary
- parse the research lab speed bonus configuration to extract the per-level value and optional cap
- update the research calculator to honour the configured bonus and clamp it to the maximum value
- extend the unit test suite with coverage for capped laboratory bonuses

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cf41dcc7c08332b609759cfa9a4572