### PR TITLE
Refactor colony view to align with new facility layout

### DIFF
--- a/public/assets/js/__tests__/card-updates.test.js
+++ b/public/assets/js/__tests__/card-updates.test.js
@@ -28,6 +28,10 @@ beforeEach(() => {
 
 test('updateBuildingCard refreshes level, costs and requirements', () => {
     document.body.innerHTML = `
+        <p class="metric-line">
+            <span class="metric-line__label">Statut</span>
+            <span class="metric-line__value metric-line__value--neutral" data-building-level="metal_mine">Non construit</span>
+        </p>
         <article class="panel building-card" data-building-card="metal_mine">
             <header class="panel__header">
                 <div class="panel__heading">
@@ -93,6 +97,11 @@ test('updateBuildingCard refreshes level, costs and requirements', () => {
     const button = card?.querySelector('button[type="submit"]');
     assert.equal(button?.disabled, true);
     assert.equal(button?.textContent, 'Conditions non remplies');
+
+    const levelDisplay = document.querySelector('[data-building-level="metal_mine"]');
+    assert.equal(levelDisplay?.textContent, 'Niveau 3');
+    assert(levelDisplay?.classList.contains('metric-line__value--positive'));
+    assert(!levelDisplay?.classList.contains('metric-line__value--neutral'));
 });
 
 test('updateResearchCard syncs progress, costs and availability', () => {


### PR DESCRIPTION
## Summary
- group building overview data into ordered categories and expose queue limits for planets
- rebuild the colony page layout around the new category data with queue metrics and facility status badges
- enhance async UI helpers so queue metrics and building level indicators stay in sync after upgrades, and extend tests accordingly

## Testing
- npm run lint
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cf411f284483328c0d98a7c310f3ce