### PR TITLE
Show research lab and shipyard speed reductions on colony page

### DIFF
--- a/src/Application/UseCase/Building/GetBuildingsOverview.php
+++ b/src/Application/UseCase/Building/GetBuildingsOverview.php
@@ -179,6 +179,26 @@ class GetBuildingsOverview
                 ];
             }
 
+            $researchSpeedCurrent = $this->calculator->researchSpeedBonusAt($definition, $currentLevel);
+            $researchSpeedNext = $this->calculator->researchSpeedBonusAt($definition, $nextTargetLevel);
+            if ($researchSpeedCurrent > 0.0 || $researchSpeedNext > 0.0) {
+                $bonuses['research_speed'] = [
+                    'current' => $researchSpeedCurrent,
+                    'next' => $researchSpeedNext,
+                    'delta' => max(0.0, $researchSpeedNext - $researchSpeedCurrent),
+                ];
+            }
+
+            $shipSpeedCurrent = $this->calculator->shipBuildSpeedBonus($definition, $currentLevel);
+            $shipSpeedNext = $this->calculator->shipBuildSpeedBonus($definition, $nextTargetLevel);
+            if ($shipSpeedCurrent > 0.0 || $shipSpeedNext > 0.0) {
+                $bonuses['ship_build_speed'] = [
+                    'current' => $shipSpeedCurrent,
+                    'next' => $shipSpeedNext,
+                    'delta' => max(0.0, $shipSpeedNext - $shipSpeedCurrent),
+                ];
+            }
+
             $buildings[] = [
                 'definition' => $definition,
                 'level' => $currentLevel,

--- a/src/Domain/Entity/BuildingDefinition.php
+++ b/src/Domain/Entity/BuildingDefinition.php
@@ -7,6 +7,7 @@ class BuildingDefinition
     /** @param array<string, int> $baseCost */
     /** @param array{buildings?: array<string, int>, research?: array<string, int>} $requirements */
     /** @param array{base?: float, growth?: float, linear?: bool, max?: float} $shipBuildSpeedBonus */
+    /** @param array<string, mixed> $researchSpeedBonus */
     /** @param array<string, array{base: float, growth: float}> $storage */
     /** @param array<string, array{base?: float, growth?: float, linear?: bool}> $upkeep */
     /** @param array<string, mixed> $constructionSpeedBonus */
@@ -26,6 +27,7 @@ class BuildingDefinition
         private readonly array $requirements = [],
         private readonly ?string $image = null,
         private readonly array $shipBuildSpeedBonus = [],
+        private readonly array $researchSpeedBonus = [],
         private readonly array $storage = [],
         private readonly array $upkeep = [],
         private readonly array $constructionSpeedBonus = []
@@ -110,6 +112,14 @@ class BuildingDefinition
     public function getShipBuildSpeedBonusConfig(): array
     {
         return $this->shipBuildSpeedBonus;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getResearchSpeedBonusConfig(): array
+    {
+        return $this->researchSpeedBonus;
     }
 
     /**

--- a/src/Domain/Service/BuildingCalculator.php
+++ b/src/Domain/Service/BuildingCalculator.php
@@ -248,7 +248,21 @@ class BuildingCalculator
             return 0.0;
         }
 
-        return $this->calculateConstructionBonus($config, $level);
+        return $this->calculateCappedBonus($config, $level);
+    }
+
+    public function researchSpeedBonusAt(BuildingDefinition $definition, int $level): float
+    {
+        if ($level <= 0) {
+            return 0.0;
+        }
+
+        $config = $definition->getResearchSpeedBonusConfig();
+        if ($config === []) {
+            return 0.0;
+        }
+
+        return $this->calculateCappedBonus($config, $level);
     }
 
     /**
@@ -282,7 +296,7 @@ class BuildingCalculator
     /**
      * @param array<string, mixed> $config
      */
-    private function calculateConstructionBonus(array $config, int $level): float
+    private function calculateCappedBonus(array $config, int $level): float
     {
         $level = max(0, $level);
         if ($level === 0) {

--- a/src/Domain/Service/BuildingCatalog.php
+++ b/src/Domain/Service/BuildingCatalog.php
@@ -32,6 +32,7 @@ class BuildingCatalog
                 $data['requires'] ?? [],
                 $data['image'] ?? null,
                 $data['ship_build_speed_bonus'] ?? [],
+                $data['research_speed_bonus'] ?? [],
                 $data['storage'] ?? [],
                 $data['upkeep'] ?? [],
                 $data['construction_speed_bonus'] ?? []

--- a/templates/pages/colony/index.php
+++ b/templates/pages/colony/index.php
@@ -162,6 +162,9 @@ ob_start();
                             $resourceKey = $production['resource'] ?? '';
                             $resourceLabel = $resourceLabels[$resourceKey] ?? ucfirst((string) $resourceKey);
                             $hasProduction = !in_array($resourceKey, ['storage', 'infrastructure'], true);
+                            $formatPercent = static function (float $value): string {
+                                return number_format($value * 100, 1) . ' %';
+                            };
                             if ($hasProduction) {
                                 $unitSuffix = $resourceKey === 'energy'
                                     ? ' énergie/h'
@@ -172,8 +175,10 @@ ob_start();
                                 $nextDisplay = $nextValue > 0 ? '+' . number_format($nextValue) : number_format($nextValue);
                                 $currentClass = $currentValue > 0 ? 'metric-line__value metric-line__value--positive' : ($currentValue < 0 ? 'metric-line__value metric-line__value--negative' : 'metric-line__value metric-line__value--neutral');
                                 $nextClass = $nextValue > 0 ? 'metric-line__value metric-line__value--positive' : ($nextValue < 0 ? 'metric-line__value metric-line__value--negative' : 'metric-line__value metric-line__value--neutral');
-                                echo '<p class="metric-line"><span class="metric-line__label">Production actuelle</span><span class="' . $currentClass . '">' . $currentDisplay . htmlspecialchars($unitSuffix) . '</span></p>';
-                                echo '<p class="metric-line"><span class="metric-line__label">Production prochain niveau</span><span class="' . $nextClass . '">' . $nextDisplay . htmlspecialchars($unitSuffix) . '</span></p>';
+                                if ($currentValue !== 0 || $nextValue !== 0) {
+                                    echo '<p class="metric-line"><span class="metric-line__label">Production actuelle</span><span class="' . $currentClass . '">' . $currentDisplay . htmlspecialchars($unitSuffix) . '</span></p>';
+                                    echo '<p class="metric-line"><span class="metric-line__label">Production prochain niveau</span><span class="' . $nextClass . '">' . $nextDisplay . htmlspecialchars($unitSuffix) . '</span></p>';
+                                }
                             }
 
                             $storage = $building['storage'] ?? [];
@@ -203,9 +208,6 @@ ob_start();
                                 $bonus = $bonuses['construction_speed'];
                                 $currentBonus = max(0.0, (float) ($bonus['current'] ?? 0.0));
                                 $nextBonus = max(0.0, (float) ($bonus['next'] ?? 0.0));
-                                $formatPercent = static function (float $value): string {
-                                    return number_format($value * 100, 1) . ' %';
-                                };
                                 $currentClass = $currentBonus > 0.0
                                     ? 'metric-line__value metric-line__value--positive'
                                     : 'metric-line__value metric-line__value--neutral';
@@ -214,6 +216,40 @@ ob_start();
                                     : 'metric-line__value metric-line__value--neutral';
                                 echo '<div class="metric-section">';
                                 echo '<p class="metric-section__title">Accélération de construction</p>';
+                                echo '<p class="metric-line"><span class="metric-line__label">Réduction actuelle</span><span class="' . $currentClass . '">-' . $formatPercent($currentBonus) . '</span></p>';
+                                echo '<p class="metric-line"><span class="metric-line__label">Réduction prochain niveau</span><span class="' . $nextClass . '">-' . $formatPercent($nextBonus) . '</span></p>';
+                                echo '</div>';
+                            }
+
+                            if (!empty($bonuses['research_speed'])) {
+                                $bonus = $bonuses['research_speed'];
+                                $currentBonus = max(0.0, (float) ($bonus['current'] ?? 0.0));
+                                $nextBonus = max(0.0, (float) ($bonus['next'] ?? 0.0));
+                                $currentClass = $currentBonus > 0.0
+                                    ? 'metric-line__value metric-line__value--positive'
+                                    : 'metric-line__value metric-line__value--neutral';
+                                $nextClass = $nextBonus > 0.0
+                                    ? 'metric-line__value metric-line__value--positive'
+                                    : 'metric-line__value metric-line__value--neutral';
+                                echo '<div class="metric-section">';
+                                echo '<p class="metric-section__title">Accélération de recherche</p>';
+                                echo '<p class="metric-line"><span class="metric-line__label">Réduction actuelle</span><span class="' . $currentClass . '">-' . $formatPercent($currentBonus) . '</span></p>';
+                                echo '<p class="metric-line"><span class="metric-line__label">Réduction prochain niveau</span><span class="' . $nextClass . '">-' . $formatPercent($nextBonus) . '</span></p>';
+                                echo '</div>';
+                            }
+
+                            if (!empty($bonuses['ship_build_speed'])) {
+                                $bonus = $bonuses['ship_build_speed'];
+                                $currentBonus = max(0.0, (float) ($bonus['current'] ?? 0.0));
+                                $nextBonus = max(0.0, (float) ($bonus['next'] ?? 0.0));
+                                $currentClass = $currentBonus > 0.0
+                                    ? 'metric-line__value metric-line__value--positive'
+                                    : 'metric-line__value metric-line__value--neutral';
+                                $nextClass = $nextBonus > 0.0
+                                    ? 'metric-line__value metric-line__value--positive'
+                                    : 'metric-line__value metric-line__value--neutral';
+                                echo '<div class="metric-section">';
+                                echo '<p class="metric-section__title">Accélération du chantier spatial</p>';
                                 echo '<p class="metric-line"><span class="metric-line__label">Réduction actuelle</span><span class="' . $currentClass . '">-' . $formatPercent($currentBonus) . '</span></p>';
                                 echo '<p class="metric-line"><span class="metric-line__label">Réduction prochain niveau</span><span class="' . $nextClass . '">-' . $formatPercent($nextBonus) . '</span></p>';
                                 echo '</div>';

--- a/tests/Unit/BuildingCalculatorTest.php
+++ b/tests/Unit/BuildingCalculatorTest.php
@@ -59,6 +59,34 @@ class BuildingCalculatorTest extends TestCase
                 'affects' => 'infrastructure',
                 'construction_speed_bonus' => ['per_level' => 0.1, 'max' => 0.75],
             ],
+            'research_lab' => [
+                'label' => 'Laboratoire expérimental',
+                'base_cost' => ['metal' => 200, 'crystal' => 320],
+                'growth_cost' => 1.6,
+                'base_time' => 40,
+                'growth_time' => 1.5,
+                'prod_base' => 0,
+                'prod_growth' => 1.0,
+                'energy_use_base' => 20,
+                'energy_use_growth' => 1.2,
+                'energy_use_linear' => true,
+                'affects' => 'energy',
+                'research_speed_bonus' => ['base' => 0.02, 'linear' => true, 'max' => 0.6],
+            ],
+            'shipyard' => [
+                'label' => 'Chantier orbital',
+                'base_cost' => ['metal' => 400, 'crystal' => 200],
+                'growth_cost' => 1.65,
+                'base_time' => 45,
+                'growth_time' => 1.4,
+                'prod_base' => 0,
+                'prod_growth' => 1.0,
+                'energy_use_base' => 30,
+                'energy_use_growth' => 1.2,
+                'energy_use_linear' => true,
+                'affects' => 'energy',
+                'ship_build_speed_bonus' => ['base' => 0.01, 'linear' => true, 'max' => 0.5],
+            ],
         ];
 
         $this->catalog = new BuildingCatalog($config);
@@ -105,6 +133,7 @@ class BuildingCalculatorTest extends TestCase
             null,
             [],
             [],
+            [],
             ['hydrogen' => ['base' => 30, 'growth' => 1.16]]
         );
 
@@ -122,6 +151,24 @@ class BuildingCalculatorTest extends TestCase
         self::assertSame(0.0, $this->calculator->constructionSpeedBonusAt($worker, 0));
         self::assertEqualsWithDelta(0.05, $this->calculator->constructionSpeedBonusAt($worker, 1), 0.0001);
         self::assertEqualsWithDelta(0.10, $this->calculator->constructionSpeedBonusAt($worker, 2), 0.0001);
+    }
+
+    public function testResearchSpeedBonusIsComputed(): void
+    {
+        $lab = $this->catalog->get('research_lab');
+
+        self::assertSame(0.0, $this->calculator->researchSpeedBonusAt($lab, 0));
+        self::assertEqualsWithDelta(0.02, $this->calculator->researchSpeedBonusAt($lab, 1), 0.0001);
+        self::assertEqualsWithDelta(0.04, $this->calculator->researchSpeedBonusAt($lab, 2), 0.0001);
+    }
+
+    public function testShipBuildSpeedBonusIsComputed(): void
+    {
+        $shipyard = $this->catalog->get('shipyard');
+
+        self::assertSame(0.0, $this->calculator->shipBuildSpeedBonus($shipyard, 0));
+        self::assertEqualsWithDelta(0.01, $this->calculator->shipBuildSpeedBonus($shipyard, 1), 0.0001);
+        self::assertEqualsWithDelta(0.02, $this->calculator->shipBuildSpeedBonus($shipyard, 2), 0.0001);
     }
 
     public function testNextTimeAppliesConstructionSpeedReductions(): void


### PR DESCRIPTION
## Summary
- compute research-lab and shipyard speed bonuses when building data is prepared
- expose research speed configuration on building definitions and calculator
- render reduction sections on the colony cards while hiding useless zero production rows
- extend calculator unit tests to cover the new bonus types

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cf43fa579483328c18a06c7886df95