### PR TITLE
Collapse tech tree sections by default

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -1644,27 +1644,86 @@ main.workspace__content {
     background: rgba(255, 255, 255, 0.04);
     border-radius: var(--radius);
     border: 1px solid rgba(255, 255, 255, 0.06);
-    padding: var(--space-4);
+    overflow: hidden;
+}
+
+.tech-section__summary {
     display: flex;
-    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
     gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    cursor: pointer;
+    list-style: none;
+    background: transparent;
+    color: var(--color-muted);
+    transition: color var(--transition-base);
+}
+
+.tech-section__summary::-webkit-details-marker {
+    display: none;
+}
+
+.tech-section__summary:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+}
+
+.tech-section__summary:hover {
+    color: var(--text-primary);
+}
+
+.tech-section[open] .tech-section__summary {
+    color: var(--text-primary);
 }
 
 .tech-section__title {
-    margin: 0;
+    flex: 1;
+    display: inline-flex;
+    align-items: center;
     font-size: var(--font-size-sm);
     text-transform: uppercase;
     letter-spacing: 0.12em;
+    font-weight: 600;
+}
+
+.tech-section__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
     color: var(--color-muted);
+    transition: transform var(--transition-base), color var(--transition-base), background var(--transition-base);
+}
+
+.tech-section__icon::before {
+    content: '›';
+    font-size: 0.875rem;
+    transform: translateX(1px);
+}
+
+.tech-section__summary:hover .tech-section__icon {
+    background: rgba(255, 255, 255, 0.16);
+    color: var(--text-primary);
+}
+
+.tech-section[open] .tech-section__icon {
+    transform: rotate(90deg);
+    background: rgba(255, 255, 255, 0.16);
+    color: var(--text-primary);
 }
 
 .tech-section__list {
     list-style: none;
     margin: 0;
-    padding: 0;
+    padding: var(--space-3) var(--space-4) var(--space-4);
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .tech-node-link {

--- a/templates/pages/tech-tree/index.php
+++ b/templates/pages/tech-tree/index.php
@@ -63,8 +63,11 @@ ob_start();
         <div class="tech-tree__layout">
             <aside class="tech-tree__sidebar">
                 <?php foreach ($categories as $category): ?>
-                    <div class="tech-section">
-                        <h2 class="tech-section__title"><?= htmlspecialchars($category['label']) ?></h2>
+                    <details class="tech-section">
+                        <summary class="tech-section__summary">
+                            <span class="tech-section__title" role="heading" aria-level="2"><?= htmlspecialchars($category['label']) ?></span>
+                            <span class="tech-section__icon" aria-hidden="true"></span>
+                        </summary>
                         <ul class="tech-section__list">
                             <?php foreach ($category['items'] as $item): ?>
                                 <?php $nodeId = $category['key'] . ':' . $item['key']; ?>
@@ -79,7 +82,7 @@ ob_start();
                                 </li>
                             <?php endforeach; ?>
                         </ul>
-                    </div>
+                    </details>
                 <?php endforeach; ?>
             </aside>
             <section class="tech-tree__details" id="tech-tree-detail" data-initial="<?= htmlspecialchars($initialNodeId ?? '') ?>" data-base-url="<?= htmlspecialchars($baseUrl) ?>">


### PR DESCRIPTION
## Summary
- wrap each technology category in the tech tree sidebar in `<details>` elements so sections start collapsed and expand individually
- restyle the tech tree sidebar headers and lists to match the new collapsible layout with focus and hover affordances

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf45112f9083328cf0e09d08b7cae3