### PR TITLE
docs: refresh readme and roadmap

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,21 @@ npm run svgo:build
 
 ---
 
+## Roadmap & évolutions multi
+- Consulter [`docs/ROADMAP.md`](./ROADMAP.md) pour suivre la progression détaillée par piliers : Solo, Multijoueur, Avancés et Bonus.
+- Aujourd'hui jouable : gestion des colonies, recherche technologique, production navale, missions et résolutions PvE, journal d'événements et ticker de ressources.
+- Priorités court terme : rendre les planètes uniques par coordonnées, ouvrir la colonisation et permettre le transport logistique entre mondes d'un même joueur.
+- Chantiers multijoueurs programmés : combats PvP, classement, échanges inter-joueurs et messagerie in-game.
+
+---
+
+## Bugs connus & TODO
+- Génération procédurale des planètes encore simplifiée : les coordonnées et caractéristiques n'impactent pas la production.
+- Colonisation multi-planètes et transferts de ressources en transit encore à implémenter côté backend et interface.
+- Mode multijoueur en conception : synchronisation temps réel, combats PvP et messagerie nécessitent une couche réseau dédiée.
+
+---
+
 ## Qualité & tests
 - **Tests unitaires** via PHPUnit (sessions, calculs bâtiments).
 - **Analyse statique** : `composer stan` (PHPStan).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,19 +1,48 @@
-SOLO
-faire que les planéte soit unique en fonction de leur coordonné (x,y), leur statistique taille et température et que 
-sa agisse sur les batiment ( exemple une planete en 1 stellaire sera plus proche du soleil et produira plus via la 
-centrail solaire)
-system de colonisation (planete, systeme de colonisation)
-system de transport de ressource entre planéte apartenant a un même joueur 
-MULTIPLAYER
-system de combat entre joueurs (attaque, defense, etc)
-systeme de transport de ressource entre planéte apartenant a des joueurs differents system de classement (top 10, top 100, top 1000, etc)
-message et notification (chat IG, notification de combat, etc)
-AVANCE
-system d'alliance et diplomatie (guerre, paix, trêve)
-marché interstellaire (achat/vente de ressource entre joueur)
-quete et evenement aleatoire (aventure, mission, etc)
-system d'exploration (planete, systeme de colonisation)
-interface et accessibilité (multi-langue, multi-OS, multi-resolution)
-performance et sécurité (optimisation, anti-hack)
+# Roadmap – Genesis Reborn
 
+> Suivi évolutif du projet. Cette feuille de route complète le README et détaille les chantiers par niveau de priorité.
 
+---
+
+## ✅ Fonctionnalités déjà en jeu
+- **Gestion des comptes** : inscription, connexion sécurisée et sessions encapsulées dans le framework maison.
+- **Colonies & bâtiments** : construction avec files d'attente, calcul des coûts et gestion de l'énergie.
+- **Recherches** : catalogue structuré avec prérequis et progression par planète.
+- **Chantier spatial & flottes** : production de vaisseaux, planification de missions, calcul du carburant et résolutions PvE.
+- **Journal & tableau de bord** : synthèse de progression, historique d'événements et ticker de ressources côté client.
+
+---
+
+## 🛠️ Prochaines étapes (Solo)
+- **Génération planétaire unique** : rendre chaque planète distincte via ses coordonnées (x, y), sa taille, sa température et leurs impacts sur la production.
+- **Système de colonisation** : capture et administration de nouvelles planètes avec limitations de slots et conditions.
+- **Logistique intra-joueur** : transport de ressources entre planètes d'un même empire avec files de convois et temps de trajet.
+
+---
+
+## 🌐 Objectifs Multijoueur
+- **Combats PvP** : attaques, défenses coordonnées et résolution simultanée.
+- **Échanges inter-joueurs** : commerce ou dons de ressources entre joueurs distincts.
+- **Classements galactiques** : top 10 / 100 / 1 000 par puissance, recherche ou richesse.
+- **Messagerie & notifications** : chat in-game, alertes de combats, rapports diplomatiques.
+
+---
+
+## 🚀 Améliorations Avancées
+- **Alliances & diplomatie** : pactes, guerres déclarées, partages de vision.
+- **Marché interstellaire** : système d'achat/vente de ressources avec taxes et fluctuations.
+- **Quêtes & événements dynamiques** : missions scénarisées, anomalies temporaires, récompenses uniques.
+- **Exploration galactique** : découverte de systèmes vierges, anomalies ou artefacts spéciaux.
+- **Interface & accessibilité** : internationalisation, support multi-résolution et options d'accessibilité.
+- **Performance & sécurité** : optimisations serveur, détection anti-cheat et monitoring.
+
+---
+
+## ⭐ Bonus (suggestions)
+- **Campagne narrative** introduisant progressivement les mécaniques et l'univers.
+- **API publique / webhooks** pour connecter des outils communautaires (bots Discord, tableaux de bord).
+- **Support de modding léger** : règles personnalisables, presets partageables entre joueurs.
+
+---
+
+_Mise à jour : 2025-09-21_


### PR DESCRIPTION
## Summary
- ajoute une section dédiée à la roadmap et un état des lieux des chantiers dans le README principal
- restructure la feuille de route avec les fonctionnalités livrées, les étapes solo/multijoueur et une liste bonus de suggestions

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68cf54474904833299c3ba38cea2d753