### PR TITLE
Add balance config loader and switch services to DTOs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": "^8.1",
         "ext-pdo": "*",
+        "symfony/yaml": "^7.3",
         "vlucas/phpdotenv": "^5.5"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "499c50426c090e1422e861052d01ff05",
+    "content-hash": "7d07893cf83543707d94dcb85705167f",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -142,6 +142,73 @@
                 }
             ],
             "time": "2025-08-21T11:53:16+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -394,6 +461,82 @@
                 }
             ],
             "time": "2025-01-02T08:10:11+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -3420,73 +3563,6 @@
                 }
             ],
             "time": "2025-08-25T06:35:40+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/event-dispatcher",

--- a/config/balance/buildings.yml
+++ b/config/balance/buildings.yml
@@ -1,0 +1,261 @@
+metal_mine:
+  label: 'Mine de métal'
+  base_cost:
+    metal: 60
+    crystal: 15
+  base_time: 20
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 100
+  prod_growth: 1.15
+  energy_use_base: 10
+  energy_use_growth: 1.1
+  energy_use_linear: true
+  affects: metal
+  image: assets/svg/illustrations/buildings/metal-mine.svg
+  requires:
+    buildings: {  }
+    research: {  }
+crystal_mine:
+  label: 'Mine de cristal'
+  base_cost:
+    metal: 48
+    crystal: 24
+  base_time: 25
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 50
+  prod_growth: 1.15
+  energy_use_base: 15
+  energy_use_growth: 1.1
+  energy_use_linear: true
+  affects: crystal
+  image: assets/svg/illustrations/buildings/crystal-mine.svg
+  requires:
+    buildings: {  }
+    research: {  }
+solar_plant:
+  label: 'Centrale solaire'
+  base_cost:
+    metal: 120
+    crystal: 60
+  base_time: 30
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 100
+  prod_growth: 1.12
+  energy_use_base: 0
+  energy_use_growth: 1.0
+  energy_use_linear: false
+  affects: energy
+  image: assets/svg/illustrations/buildings/solar-plant.svg
+  requires:
+    buildings: {  }
+    research: {  }
+fusion_reactor:
+  label: 'Réacteur à fusion'
+  base_cost:
+    metal: 900
+    crystal: 360
+    hydrogen: 180
+  base_time: 60
+  growth_cost: 1.55
+  growth_time: 1.6
+  prod_base: 320
+  prod_growth: 1.18
+  energy_use_base: 0
+  energy_use_growth: 1.0
+  energy_use_linear: false
+  affects: energy
+  image: assets/svg/illustrations/buildings/fusion-reactor.svg
+  requires:
+    buildings:
+      solar_plant: 5
+      hydrogen_plant: 3
+    research:
+      reactor_advanced: 2
+  upkeep:
+    hydrogen:
+      base: 30
+      growth: 1.16
+antimatter_reactor:
+  label: 'Réacteur à antimatière'
+  base_cost:
+    metal: 3200
+    crystal: 2200
+    hydrogen: 1200
+  base_time: 90
+  growth_cost: 1.55
+  growth_time: 1.6
+  prod_base: 800
+  prod_growth: 1.2
+  energy_use_base: 0
+  energy_use_growth: 1.0
+  energy_use_linear: false
+  affects: energy
+  image: assets/svg/illustrations/buildings/antimatter-reactor.svg
+  requires:
+    buildings:
+      fusion_reactor: 5
+      research_lab: 6
+    research:
+      reactor_antimatter: 1
+  upkeep:
+    hydrogen:
+      base: 60
+      growth: 1.2
+hydrogen_plant:
+  label: 'Générateur d’hydrogène'
+  base_cost:
+    metal: 150
+    crystal: 100
+  base_time: 35
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 30
+  prod_growth: 1.15
+  energy_use_base: 20
+  energy_use_growth: 1.1
+  energy_use_linear: true
+  affects: hydrogen
+  image: assets/svg/illustrations/buildings/hydrogen-plant.svg
+  requires:
+    buildings:
+      solar_plant: 1
+    research: {  }
+storage_depot:
+  label: 'Entrepôt planétaire'
+  base_cost:
+    metal: 1000
+    crystal: 400
+  base_time: 55
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 0
+  energy_use_growth: 1.0
+  energy_use_linear: false
+  affects: storage
+  image: assets/svg/illustrations/buildings/storage-depot.svg
+  requires:
+    buildings:
+      metal_mine: 4
+      crystal_mine: 3
+    research:
+      logistics: 2
+  storage:
+    metal:
+      base: 50000
+      growth: 1.6
+    crystal:
+      base: 40000
+      growth: 1.6
+    hydrogen:
+      base: 30000
+      growth: 1.6
+    energy:
+      base: 2500
+      growth: 1.5
+worker_factory:
+  label: 'Complexe d’ouvriers'
+  base_cost:
+    metal: 420
+    crystal: 160
+  base_time: 45
+  growth_cost: 1.6
+  growth_time: 1.55
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 18
+  energy_use_growth: 1.12
+  energy_use_linear: true
+  affects: infrastructure
+  image: assets/svg/illustrations/buildings/worker-factory.svg
+  requires:
+    buildings:
+      metal_mine: 4
+      crystal_mine: 3
+    research: {  }
+  construction_speed_bonus:
+    per_level: 0.01
+    max: 0.99
+robot_factory:
+  label: 'Chantier robotique'
+  base_cost:
+    metal: 2400
+    crystal: 1200
+    hydrogen: 300
+  base_time: 85
+  growth_cost: 1.75
+  growth_time: 1.65
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 36
+  energy_use_growth: 1.2
+  energy_use_linear: true
+  affects: infrastructure
+  image: assets/svg/illustrations/buildings/robot-factory.svg
+  requires:
+    buildings:
+      worker_factory: 6
+      research_lab: 2
+    research:
+      engineering_heavy: 3
+  construction_speed_bonus:
+    per_level: 0.03
+    max: 0.99
+  upkeep:
+    hydrogen:
+      base: 12
+      growth: 1.15
+research_lab:
+  label: 'Laboratoire Helios'
+  base_cost:
+    metal: 200
+    crystal: 320
+    hydrogen: 80
+  base_time: 40
+  growth_cost: 1.65
+  growth_time: 1.6
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 22
+  energy_use_growth: 1.22
+  energy_use_linear: true
+  affects: energy
+  image: assets/svg/illustrations/buildings/research-lab.svg
+  requires:
+    buildings:
+      solar_plant: 1
+      crystal_mine: 1
+    research: {  }
+  research_speed_bonus:
+    base: 0.01
+    linear: true
+    max: 0.99
+shipyard:
+  label: 'Chantier spatial Asterion'
+  base_cost:
+    metal: 420
+    crystal: 260
+    hydrogen: 120
+  base_time: 45
+  growth_cost: 1.7
+  growth_time: 1.65
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 35
+  energy_use_growth: 1.25
+  energy_use_linear: true
+  affects: energy
+  ship_build_speed_bonus:
+    base: 0.01
+    linear: true
+    max: 0.99
+  image: assets/svg/illustrations/buildings/shipyard.svg
+  requires:
+    buildings:
+      research_lab: 1
+    research:
+      engineering_heavy: 1

--- a/config/balance/globals.yml
+++ b/config/balance/globals.yml
@@ -1,0 +1,10 @@
+initial_resources:
+  metal: 1000
+  crystal: 1000
+  hydrogen: 1000
+  energy: 0
+initial_capacities:
+  metal: 1000
+  crystal: 1000
+  hydrogen: 1000
+  energy: 1000

--- a/config/balance/ships.yml
+++ b/config/balance/ships.yml
@@ -1,0 +1,481 @@
+fighter:
+  label: 'Ailes Lyrae'
+  category: 'Petits vaisseaux'
+  role: 'Chasseur léger de supériorité spatiale'
+  description: 'Véhicule agile conçu pour intercepter rapidement les menaces proches et saturer la défense adverse.'
+  base_cost:
+    metal: 220
+    crystal: 90
+    hydrogen: 45
+  build_time: 60
+  stats:
+    attaque: 6
+    défense: 3
+    vitesse: 18
+  requires_research:
+    propulsion_basic: 1
+    life_support: 2
+    miniaturisation: 2
+    weapon_light: 2
+    radar_basic: 1
+  image: assets/svg/illustrations/ships/light-wing.svg
+bomber:
+  label: 'Maraudeur Obsidien'
+  category: 'Petits vaisseaux'
+  role: 'Bombardier d’assaut lourd'
+  description: 'Transporte un arsenal de torpilles magnétiques capables de briser le blindage des cibles capitales.'
+  base_cost:
+    metal: 420
+    crystal: 260
+    hydrogen: 120
+  build_time: 140
+  stats:
+    attaque: 15
+    défense: 6
+    vitesse: 12
+  requires_research:
+    life_support: 2
+    miniaturisation: 2
+    armor_basic: 2
+    weapon_light: 6
+    weapon_medium: 1
+  image: assets/svg/illustrations/ships/light-wing.svg
+interceptor:
+  label: 'Éclair Stentor'
+  category: 'Petits vaisseaux'
+  role: 'Intercepteur ultrarapide'
+  description: 'Priorité à la vitesse et à la précision pour contrer les chasseurs ennemis et les éclaireurs.'
+  base_cost:
+    metal: 280
+    crystal: 160
+    hydrogen: 90
+  build_time: 90
+  stats:
+    attaque: 7
+    défense: 4
+    vitesse: 24
+  requires_research:
+    propulsion_basic: 2
+    life_support: 3
+    miniaturisation: 3
+    weapon_light: 3
+    radar_basic: 3
+  image: assets/svg/illustrations/ships/light-wing.svg
+heavy_fighter:
+  label: 'Griffon Halcyon'
+  category: 'Petits vaisseaux'
+  role: 'Chasseur lourd polyvalent'
+  description: 'Combine l’armement d’un bombardier à la mobilité d’un intercepteur pour dominer la ligne de front.'
+  base_cost:
+    metal: 520
+    crystal: 360
+    hydrogen: 160
+  build_time: 180
+  stats:
+    attaque: 18
+    défense: 10
+    vitesse: 16
+  requires_research:
+    propulsion_basic: 3
+    life_support: 3
+    miniaturisation: 4
+    weapon_light: 4
+    radar_basic: 3
+    armor_basic: 3
+  image: assets/svg/illustrations/ships/light-wing.svg
+corvette:
+  label: 'Corvette Vigilum'
+  category: 'Unités d’escorte'
+  role: 'Plateforme polyvalente de patrouille'
+  description: 'Assure la reconnaissance, la couverture anti-chasseur et la projection rapide de puissance légère.'
+  base_cost:
+    metal: 950
+    crystal: 520
+    hydrogen: 220
+  build_time: 300
+  stats:
+    attaque: 28
+    défense: 22
+    vitesse: 14
+  requires_research:
+    propulsion_basic: 4
+    life_support: 4
+    logistics: 1
+    armor_basic: 5
+    armor_enhanced: 1
+    weapon_light: 6
+    weapon_medium: 3
+    radar_basic: 3
+  image: assets/svg/illustrations/ships/escort-frigate.svg
+gunship:
+  label: 'Havoc Aster'
+  category: 'Unités d’escorte'
+  role: 'Canonnière à saturation de feu'
+  description: 'Embarque des canons à plasma lourds pour perforer les coques des navires moyens.'
+  base_cost:
+    metal: 1250
+    crystal: 720
+    hydrogen: 260
+  build_time: 420
+  stats:
+    attaque: 40
+    défense: 28
+    vitesse: 12
+  requires_research:
+    armor_basic: 5
+    armor_enhanced: 1
+    weapon_light: 6
+    weapon_medium: 2
+    radar_basic: 3
+  image: assets/svg/illustrations/ships/escort-frigate.svg
+frigate:
+  label: 'Frégate Solstice'
+  category: 'Unités d’escorte'
+  role: 'Frégate anti-chasseur'
+  description: 'Grille de missiles défensifs et batteries traçantes pour protéger les unités capitales.'
+  base_cost:
+    metal: 2200
+    crystal: 1350
+    hydrogen: 480
+  build_time: 600
+  stats:
+    attaque: 55
+    défense: 48
+    vitesse: 10
+  requires_research:
+    armor_basic: 5
+    armor_enhanced: 3
+    weapon_light: 4
+    shield_energy: 1
+    weapon_medium: 4
+    propulsion_basic: 4
+    life_support: 4
+    logistics: 2
+    tactical_coordination: 1
+  image: assets/svg/illustrations/ships/escort-frigate.svg
+destroyer:
+  label: 'Destroyer Fulguris'
+  category: 'Navires de ligne'
+  role: 'Chasseur de frégates et croiseurs'
+  description: 'Longue coque bardée de canons rails optimisés pour démanteler les escorteurs ennemis.'
+  base_cost:
+    metal: 3600
+    crystal: 2400
+    hydrogen: 800
+  build_time: 900
+  stats:
+    attaque: 80
+    défense: 60
+    vitesse: 9
+  requires_research:
+    engineering_heavy: 2
+    propulsion_basic: 5
+    reactor_advanced: 2
+    weapon_light: 6
+    weapon_medium: 5
+    weapon_heavy: 1
+    tactical_coordination: 3
+  image: assets/svg/illustrations/ships/line-cruiser.svg
+light_cruiser:
+  label: 'Croiseur Lumen'
+  category: 'Navires de ligne'
+  role: 'Croiseur léger polyvalent'
+  description: 'Équilibre propulsion, blindage et puissance de feu pour mener des flottes rapides.'
+  base_cost:
+    metal: 5200
+    crystal: 3600
+    hydrogen: 1200
+  build_time: 1200
+  stats:
+    attaque: 110
+    défense: 95
+    vitesse: 8
+  requires_research:
+    engineering_heavy: 3
+    armor_basic: 6
+    armor_enhanced: 3
+    weapon_light: 4
+    shield_energy: 3
+    reactor_advanced: 3
+    weapon_medium: 5
+    weapon_heavy: 2
+    tactical_coordination: 3
+  image: assets/svg/illustrations/ships/line-cruiser.svg
+heavy_cruiser:
+  label: 'Croiseur Axiom'
+  category: 'Navires de ligne'
+  role: 'Croiseur lourd de percée'
+  description: 'Blindage renforcé, artillerie lourde et systèmes de projection pour les batailles d’attrition.'
+  base_cost:
+    metal: 8800
+    crystal: 6200
+    hydrogen: 1800
+  build_time: 1800
+  stats:
+    attaque: 150
+    défense: 140
+    vitesse: 7
+  requires_research:
+    engineering_heavy: 5
+    superstructures: 1
+    reactor_advanced: 4
+    weapon_medium: 5
+    weapon_heavy: 3
+    armor_basic: 6
+    armor_enhanced: 6
+    weapon_light: 5
+    shield_energy: 5
+    defense_multilayer: 2
+    tactical_coordination: 4
+  image: assets/svg/illustrations/ships/line-cruiser.svg
+battleship:
+  label: 'Cuirassé Helior'
+  category: 'Navires lourds'
+  role: 'Cuirassé de ligne'
+  description: 'Boucliers étagés et batteries orbitales massives pour absorber et infliger d’énormes dégâts.'
+  base_cost:
+    metal: 15000
+    crystal: 9800
+    hydrogen: 2600
+  build_time: 2700
+  stats:
+    attaque: 220
+    défense: 260
+    vitesse: 6
+  requires_research:
+    engineering_heavy: 5
+    superstructures: 4
+    reactor_advanced: 6
+    reactor_antimatter: 1
+    weapon_medium: 6
+    weapon_heavy: 6
+    weapon_capital: 1
+    armor_basic: 6
+    armor_enhanced: 6
+    weapon_light: 5
+    shield_energy: 5
+    defense_multilayer: 3
+  image: assets/svg/illustrations/ships/heavy-battleship.svg
+battlecruiser:
+  label: 'Arbiter Solaris'
+  category: 'Navires lourds'
+  role: 'Croiseur de bataille'
+  description: 'Compromis entre vitesse et artillerie lourde pour manœuvrer autour des cuirassés ennemis.'
+  base_cost:
+    metal: 18800
+    crystal: 12600
+    hydrogen: 3200
+  build_time: 3300
+  stats:
+    attaque: 240
+    défense: 210
+    vitesse: 7
+  requires_research:
+    engineering_heavy: 5
+    superstructures: 2
+    reactor_advanced: 5
+    weapon_medium: 5
+    weapon_heavy: 4
+    tactical_coordination: 5
+  image: assets/svg/illustrations/ships/heavy-battleship.svg
+dreadnought:
+  label: 'Dreadnought Orichal'
+  category: 'Navires lourds'
+  role: 'Dreadnought d’assaut'
+  description: 'Pièce maîtresse d’une armada, concentrant le feu de multiples batteries super-lourdes.'
+  base_cost:
+    metal: 26000
+    crystal: 18000
+    hydrogen: 4200
+  build_time: 4200
+  stats:
+    attaque: 320
+    défense: 320
+    vitesse: 5
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 4
+    reactor_advanced: 6
+    reactor_antimatter: 2
+    weapon_heavy: 6
+    weapon_capital: 2
+    armor_enhanced: 6
+    shield_energy: 5
+    defense_multilayer: 4
+    tactical_coordination: 6
+    stellar_shipyards: 2
+  image: assets/svg/illustrations/ships/heavy-battleship.svg
+carrier:
+  label: 'Porte-chasseurs Aegira'
+  category: 'Capitaux spécialisés'
+  role: 'Transport et projection de chasseurs'
+  description: 'Hangars magnétiques pouvant lancer simultanément des vagues complètes d’escadrilles.'
+  base_cost:
+    metal: 22000
+    crystal: 21000
+    hydrogen: 5200
+  build_time: 4500
+  stats:
+    attaque: 180
+    défense: 300
+    vitesse: 5
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 5
+    stellar_shipyards: 2
+    tactical_coordination: 4
+    autonomous_hangars: 3
+    reactor_advanced: 5
+    weapon_medium: 5
+    shield_energy: 5
+    armor_enhanced: 6
+    fleet_networks: 2
+  image: assets/svg/illustrations/ships/capital-carrier.svg
+heavy_transport:
+  label: 'Transporteur Atlas'
+  category: 'Capitaux spécialisés'
+  role: 'Transport lourd interplanétaire'
+  description: 'Plate-forme d’atterrissage blindée pour déployer troupes, véhicules ou modules orbitaux.'
+  base_cost:
+    metal: 12800
+    crystal: 9000
+    hydrogen: 6400
+  build_time: 3000
+  stats:
+    attaque: 70
+    défense: 150
+    vitesse: 6
+  requires_research:
+    propulsion_basic: 4
+    life_support: 4
+    logistics: 3
+    engineering_heavy: 2
+    armor_basic: 3
+    weapon_light: 3
+    tactical_coordination: 1
+  image: assets/svg/illustrations/ships/capital-carrier.svg
+command_ship:
+  label: 'Vaisseau de commandement Novarch'
+  category: 'Capitaux spécialisés'
+  role: 'Centre de commandement stratégique'
+  description: 'Coordinateur de flotte doté de suites tactiques avancées et de systèmes de communications quantiques.'
+  base_cost:
+    metal: 24000
+    crystal: 20000
+    hydrogen: 7000
+  build_time: 4800
+  stats:
+    attaque: 160
+    défense: 340
+    vitesse: 5
+  requires_research:
+    tactical_coordination: 5
+    fleet_networks: 2
+    autonomous_hangars: 2
+    shield_energy: 4
+    armor_enhanced: 4
+    weapon_medium: 4
+  image: assets/svg/illustrations/ships/capital-carrier.svg
+super_battleship:
+  label: 'Super-cuirassé Empyrium'
+  category: 'Vaisseaux colossaux'
+  role: 'Super-cuirassé de domination'
+  description: 'Vaisseau emblématique, quasiment indestructible, arborant une armure multi-couches et un armement d’anéantissement.'
+  base_cost:
+    metal: 54000
+    crystal: 42000
+    hydrogen: 12000
+  build_time: 9000
+  stats:
+    attaque: 420
+    défense: 520
+    vitesse: 4
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 5
+    stellar_shipyards: 3
+    reactor_advanced: 6
+    reactor_antimatter: 3
+    weapon_heavy: 6
+    weapon_capital: 3
+    armor_enhanced: 6
+    shield_energy: 5
+    defense_multilayer: 5
+  image: assets/svg/illustrations/ships/colossus.svg
+siege_breaker:
+  label: 'Cuirassé de siège Ragnarok'
+  category: 'Vaisseaux colossaux'
+  role: 'Bélier orbital'
+  description: 'Optimisé pour raser les fortifications planétaires grâce à des canons gravitoniques massifs.'
+  base_cost:
+    metal: 62000
+    crystal: 46000
+    hydrogen: 15000
+  build_time: 9600
+  stats:
+    attaque: 480
+    défense: 480
+    vitesse: 4
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 5
+    stellar_shipyards: 3
+    weapon_capital: 3
+    super_weapon: 1
+    reactor_antimatter: 3
+    defense_multilayer: 4
+    shield_energy: 5
+  image: assets/svg/illustrations/ships/colossus.svg
+super_dreadnought:
+  label: 'Super-dreadnought Nemesis'
+  category: 'Vaisseaux colossaux'
+  role: 'Arme capitale ultime'
+  description: 'Capable de déployer un canon stellaire, ce navire dicte l’issue de n’importe quelle bataille.'
+  base_cost:
+    metal: 72000
+    crystal: 56000
+    hydrogen: 18000
+  build_time: 10800
+  stats:
+    attaque: 560
+    défense: 580
+    vitesse: 3
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 5
+    stellar_shipyards: 3
+    reactor_advanced: 6
+    reactor_antimatter: 4
+    weapon_heavy: 6
+    weapon_capital: 4
+    super_weapon: 1
+    armor_enhanced: 6
+    shield_energy: 5
+    defense_multilayer: 5
+    fleet_networks: 3
+  image: assets/svg/illustrations/ships/colossus.svg
+battle_station:
+  label: 'Citadelle Astra'
+  category: 'Stations stellaires'
+  role: 'Station spatiale armée'
+  description: 'Forteresse orbitale dotée d’un anneau de super-lasers et de plates-formes autonomes.'
+  base_cost:
+    metal: 95000
+    crystal: 82000
+    hydrogen: 25000
+  build_time: 14400
+  stats:
+    attaque: 680
+    défense: 760
+    vitesse: 0
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 6
+    stellar_shipyards: 4
+    armor_enhanced: 6
+    shield_energy: 5
+    defense_multilayer: 5
+    weapon_capital: 3
+    super_weapon: 1
+    fleet_networks: 3
+  image: assets/svg/illustrations/ships/battle-station.svg

--- a/config/balance/technologies.yml
+++ b/config/balance/technologies.yml
@@ -1,0 +1,362 @@
+propulsion_basic:
+  label: 'Propulsion spatiale'
+  category: Propulsion
+  description: 'Maîtrise des moteurs ioniques et de la navigation subluminique.'
+  base_cost:
+    metal: 120
+    crystal: 80
+    hydrogen: 40
+  base_time: 50
+  growth_cost: 1.65
+  growth_time: 1.6
+  max_level: 10
+  requires: {  }
+  requires_lab: 1
+  image: assets/svg/illustrations/research/propulsion.svg
+life_support:
+  label: 'Systèmes de survie'
+  category: Ingénierie
+  description: 'Contrôle environnemental, recyclage et maintien des équipages.'
+  base_cost:
+    metal: 90
+    crystal: 110
+    hydrogen: 40
+  base_time: 55
+  growth_cost: 1.6
+  growth_time: 1.55
+  max_level: 10
+  requires: {  }
+  requires_lab: 1
+  image: assets/svg/illustrations/research/engineering.svg
+miniaturisation:
+  label: 'Miniaturisation des systèmes'
+  category: Ingénierie
+  description: 'Réduction des composants pour optimiser la place à bord.'
+  base_cost:
+    metal: 140
+    crystal: 150
+    hydrogen: 60
+  base_time: 60
+  growth_cost: 1.65
+  growth_time: 1.6
+  max_level: 10
+  requires:
+    life_support: 2
+  requires_lab: 1
+  image: assets/svg/illustrations/research/engineering.svg
+armor_basic:
+  label: 'Blindage de base'
+  category: Défense
+  description: 'Plaques composites et renforts structurels élémentaires.'
+  base_cost:
+    metal: 160
+    crystal: 120
+    hydrogen: 40
+  base_time: 65
+  growth_cost: 1.65
+  growth_time: 1.65
+  max_level: 10
+  requires:
+    miniaturisation: 2
+  requires_lab: 1
+  image: assets/svg/illustrations/research/defense.svg
+weapon_light:
+  label: 'Armes légères'
+  category: Armement
+  description: 'Lasers, canons automatiques et missiles à courte portée.'
+  base_cost:
+    metal: 150
+    crystal: 170
+    hydrogen: 60
+  base_time: 70
+  growth_cost: 1.65
+  growth_time: 1.6
+  max_level: 10
+  requires:
+    miniaturisation: 2
+  requires_lab: 1
+  image: assets/svg/illustrations/research/armament.svg
+radar_basic:
+  label: 'Détection basique'
+  category: Capteurs
+  description: 'Radars tactiques et balayage à courte portée.'
+  base_cost:
+    metal: 110
+    crystal: 160
+    hydrogen: 60
+  base_time: 65
+  growth_cost: 1.6
+  growth_time: 1.55
+  max_level: 10
+  requires:
+    miniaturisation: 1
+  requires_lab: 1
+  image: assets/svg/illustrations/research/sensors.svg
+armor_enhanced:
+  label: 'Blindage renforcé'
+  category: Défense
+  description: 'Alliages avancés et champs de confinement structurels.'
+  base_cost:
+    metal: 260
+    crystal: 210
+    hydrogen: 90
+  base_time: 90
+  growth_cost: 1.7
+  growth_time: 1.65
+  max_level: 10
+  requires:
+    armor_basic: 5
+  requires_lab: 2
+  image: assets/svg/illustrations/research/defense.svg
+shield_energy:
+  label: 'Boucliers énergétiques'
+  category: Défense
+  description: 'Générateurs de champs déflecteurs et boucliers phaseurs.'
+  base_cost:
+    metal: 240
+    crystal: 260
+    hydrogen: 140
+  base_time: 95
+  growth_cost: 1.72
+  growth_time: 1.65
+  max_level: 10
+  requires:
+    armor_enhanced: 3
+    weapon_light: 4
+  requires_lab: 2
+  image: assets/svg/illustrations/research/defense.svg
+weapon_medium:
+  label: 'Armes moyennes'
+  category: Armement
+  description: 'Torpilles lourdes et batteries laser à longue portée.'
+  base_cost:
+    metal: 260
+    crystal: 280
+    hydrogen: 160
+  base_time: 100
+  growth_cost: 1.7
+  growth_time: 1.65
+  max_level: 10
+  requires:
+    weapon_light: 6
+  requires_lab: 2
+  image: assets/svg/illustrations/research/armament.svg
+logistics:
+  label: 'Logistique spatiale'
+  category: Ingénierie
+  description: 'Ravitaillement interplanétaire et coordination des convois.'
+  base_cost:
+    metal: 220
+    crystal: 200
+    hydrogen: 140
+  base_time: 90
+  growth_cost: 1.68
+  growth_time: 1.62
+  max_level: 10
+  requires:
+    propulsion_basic: 4
+    life_support: 4
+  requires_lab: 2
+  image: assets/svg/illustrations/research/engineering.svg
+engineering_heavy:
+  label: 'Ingénierie lourde'
+  category: Ingénierie
+  description: 'Conception de structures massives et docks orbitaux.'
+  base_cost:
+    metal: 320
+    crystal: 260
+    hydrogen: 160
+  base_time: 110
+  growth_cost: 1.72
+  growth_time: 1.68
+  max_level: 10
+  requires:
+    logistics: 3
+  requires_lab: 2
+  image: assets/svg/illustrations/research/engineering.svg
+reactor_advanced:
+  label: 'Réacteurs avancés'
+  category: Propulsion
+  description: 'Réacteurs à fusion haute densité et confinement magnétique.'
+  base_cost:
+    metal: 380
+    crystal: 340
+    hydrogen: 200
+  base_time: 130
+  growth_cost: 1.75
+  growth_time: 1.7
+  max_level: 10
+  requires:
+    propulsion_basic: 5
+    engineering_heavy: 2
+  requires_lab: 3
+  image: assets/svg/illustrations/research/propulsion.svg
+weapon_heavy:
+  label: 'Armes lourdes'
+  category: Armement
+  description: 'Railguns, canons à plasma et plates-formes multi-batteries.'
+  base_cost:
+    metal: 420
+    crystal: 380
+    hydrogen: 260
+  base_time: 140
+  growth_cost: 1.75
+  growth_time: 1.72
+  max_level: 10
+  requires:
+    weapon_medium: 5
+    reactor_advanced: 2
+  requires_lab: 3
+  image: assets/svg/illustrations/research/armament.svg
+tactical_coordination:
+  label: 'Coordination tactique'
+  category: Commandement
+  description: 'IA stratégique et communications quantiques longue portée.'
+  base_cost:
+    metal: 360
+    crystal: 420
+    hydrogen: 200
+  base_time: 135
+  growth_cost: 1.7
+  growth_time: 1.68
+  max_level: 10
+  requires:
+    radar_basic: 5
+    logistics: 5
+  requires_lab: 3
+  image: assets/svg/illustrations/research/command.svg
+superstructures:
+  label: Superstructures
+  category: Ingénierie
+  description: 'Coques modulaires géantes et architecture segmentée.'
+  base_cost:
+    metal: 520
+    crystal: 460
+    hydrogen: 260
+  base_time: 150
+  growth_cost: 1.78
+  growth_time: 1.72
+  max_level: 10
+  requires:
+    engineering_heavy: 5
+  requires_lab: 4
+  image: assets/svg/illustrations/research/engineering.svg
+reactor_antimatter:
+  label: 'Réacteurs à antimatière'
+  category: Propulsion
+  description: 'Confinement annulaire et catalyseurs d’antimatière.'
+  base_cost:
+    metal: 620
+    crystal: 540
+    hydrogen: 340
+  base_time: 170
+  growth_cost: 1.8
+  growth_time: 1.75
+  max_level: 10
+  requires:
+    reactor_advanced: 6
+    superstructures: 3
+  requires_lab: 4
+  image: assets/svg/illustrations/research/propulsion.svg
+weapon_capital:
+  label: 'Armement capital'
+  category: Armement
+  description: 'Super-canons, bombardement orbital et charges de siège.'
+  base_cost:
+    metal: 680
+    crystal: 620
+    hydrogen: 360
+  base_time: 180
+  growth_cost: 1.82
+  growth_time: 1.76
+  max_level: 10
+  requires:
+    weapon_heavy: 6
+    superstructures: 4
+  requires_lab: 4
+  image: assets/svg/illustrations/research/armament.svg
+defense_multilayer:
+  label: 'Défense multi-couches'
+  category: Défense
+  description: 'Combinaison de boucliers adaptatifs et d’armures composites.'
+  base_cost:
+    metal: 640
+    crystal: 560
+    hydrogen: 340
+  base_time: 175
+  growth_cost: 1.78
+  growth_time: 1.74
+  max_level: 10
+  requires:
+    armor_enhanced: 6
+    shield_energy: 5
+  requires_lab: 4
+  image: assets/svg/illustrations/research/defense.svg
+stellar_shipyards:
+  label: 'Chantiers stellaires'
+  category: Construction
+  description: 'Assemblage orbital massif et infrastructures d’amarrage.'
+  base_cost:
+    metal: 720
+    crystal: 660
+    hydrogen: 420
+  base_time: 185
+  growth_cost: 1.8
+  growth_time: 1.76
+  max_level: 10
+  requires:
+    superstructures: 5
+    engineering_heavy: 7
+  requires_lab: 4
+  image: assets/svg/illustrations/research/construction.svg
+autonomous_hangars:
+  label: 'Hangars autonomes'
+  category: Construction
+  description: 'Réseaux de lancement automatisés pour escadrilles de chasseurs.'
+  base_cost:
+    metal: 760
+    crystal: 680
+    hydrogen: 440
+  base_time: 190
+  growth_cost: 1.8
+  growth_time: 1.78
+  max_level: 10
+  requires:
+    stellar_shipyards: 2
+    tactical_coordination: 4
+  requires_lab: 4
+  image: assets/svg/illustrations/research/construction.svg
+super_weapon:
+  label: 'Armes de destruction massive'
+  category: Armement
+  description: 'Rayons planétaires, bombardements orbitaux et super-armes.'
+  base_cost:
+    metal: 880
+    crystal: 760
+    hydrogen: 520
+  base_time: 210
+  growth_cost: 1.85
+  growth_time: 1.8
+  max_level: 10
+  requires:
+    weapon_capital: 4
+    reactor_antimatter: 4
+  requires_lab: 5
+  image: assets/svg/illustrations/research/armament.svg
+fleet_networks:
+  label: 'Réseaux stratégiques de flotte'
+  category: Commandement
+  description: 'Commandement interstellaire et coordination des armadas.'
+  base_cost:
+    metal: 820
+    crystal: 780
+    hydrogen: 480
+  base_time: 205
+  growth_cost: 1.82
+  growth_time: 1.78
+  max_level: 10
+  requires:
+    tactical_coordination: 6
+    autonomous_hangars: 3
+  requires_lab: 5
+  image: assets/svg/illustrations/research/command.svg

--- a/src/Domain/Service/BuildingCatalog.php
+++ b/src/Domain/Service/BuildingCatalog.php
@@ -3,6 +3,7 @@
 namespace App\Domain\Service;
 
 use App\Domain\Entity\BuildingDefinition;
+use App\Infrastructure\Config\BuildingConfig;
 use InvalidArgumentException;
 
 class BuildingCatalog
@@ -11,31 +12,37 @@ class BuildingCatalog
     private array $definitions = [];
 
     /**
-     * @param array<string, array<string, mixed>> $config
+     * @param iterable<BuildingConfig> $configs
      */
-    public function __construct(array $config)
+    public function __construct(iterable $configs)
     {
-        foreach ($config as $key => $data) {
+        foreach ($configs as $config) {
+            if (!$config instanceof BuildingConfig) {
+                throw new InvalidArgumentException('BuildingCatalog expects instances of BuildingConfig.');
+            }
+
+            $key = $config->getKey();
+
             $this->definitions[$key] = new BuildingDefinition(
                 $key,
-                $data['label'],
-                $data['base_cost'],
-                (float) $data['growth_cost'],
-                (int) $data['base_time'],
-                (float) $data['growth_time'],
-                (int) ($data['prod_base'] ?? 0),
-                (float) ($data['prod_growth'] ?? 1.0),
-                (int) ($data['energy_use_base'] ?? 0),
-                (float) ($data['energy_use_growth'] ?? 1.0),
-                (bool) ($data['energy_use_linear'] ?? false),
-                $data['affects'],
-                $data['requires'] ?? [],
-                $data['image'] ?? null,
-                $data['ship_build_speed_bonus'] ?? [],
-                $data['research_speed_bonus'] ?? [],
-                $data['storage'] ?? [],
-                $data['upkeep'] ?? [],
-                $data['construction_speed_bonus'] ?? []
+                $config->getLabel(),
+                $config->getBaseCost(),
+                $config->getGrowthCost(),
+                $config->getBaseTime(),
+                $config->getGrowthTime(),
+                $config->getProductionBase(),
+                $config->getProductionGrowth(),
+                $config->getEnergyUseBase(),
+                $config->getEnergyUseGrowth(),
+                $config->isEnergyUseLinear(),
+                $config->getAffects(),
+                $config->getRequirements(),
+                $config->getImage(),
+                $config->getShipBuildSpeedBonus(),
+                $config->getResearchSpeedBonus(),
+                $config->getStorage(),
+                $config->getUpkeep(),
+                $config->getConstructionSpeedBonus()
             );
         }
     }

--- a/src/Domain/Service/ResearchCatalog.php
+++ b/src/Domain/Service/ResearchCatalog.php
@@ -3,6 +3,7 @@
 namespace App\Domain\Service;
 
 use App\Domain\Entity\ResearchDefinition;
+use App\Infrastructure\Config\TechnologyConfig;
 use InvalidArgumentException;
 
 class ResearchCatalog
@@ -14,24 +15,30 @@ class ResearchCatalog
     private array $categories = [];
 
     /**
-     * @param array<string, array<string, mixed>> $config
+     * @param iterable<TechnologyConfig> $configs
      */
-    public function __construct(array $config)
+    public function __construct(iterable $configs)
     {
-        foreach ($config as $key => $data) {
+        foreach ($configs as $config) {
+            if (!$config instanceof TechnologyConfig) {
+                throw new InvalidArgumentException('ResearchCatalog expects instances of TechnologyConfig.');
+            }
+
+            $key = $config->getKey();
+
             $definition = new ResearchDefinition(
                 $key,
-                $data['label'],
-                $data['category'],
-                $data['description'] ?? '',
-                $data['base_cost'],
-                (int) $data['base_time'],
-                (float) ($data['growth_cost'] ?? 1.0),
-                (float) ($data['growth_time'] ?? 1.0),
-                (int) ($data['max_level'] ?? 10),
-                $data['requires'] ?? [],
-                (int) ($data['requires_lab'] ?? 0),
-                $data['image'] ?? ''
+                $config->getLabel(),
+                $config->getCategory(),
+                $config->getDescription(),
+                $config->getBaseCost(),
+                $config->getBaseTime(),
+                $config->getGrowthCost(),
+                $config->getGrowthTime(),
+                $config->getMaxLevel(),
+                $config->getRequires(),
+                $config->getRequiresLab(),
+                $config->getImage() ?? ''
             );
 
             $this->definitions[$key] = $definition;

--- a/src/Domain/Service/ShipCatalog.php
+++ b/src/Domain/Service/ShipCatalog.php
@@ -3,6 +3,7 @@
 namespace App\Domain\Service;
 
 use App\Domain\Entity\ShipDefinition;
+use App\Infrastructure\Config\ShipConfig;
 use InvalidArgumentException;
 
 class ShipCatalog
@@ -14,22 +15,28 @@ class ShipCatalog
     private array $categories = [];
 
     /**
-     * @param array<string, array<string, mixed>> $config
+     * @param iterable<ShipConfig> $configs
      */
-    public function __construct(array $config)
+    public function __construct(iterable $configs)
     {
-        foreach ($config as $key => $data) {
+        foreach ($configs as $config) {
+            if (!$config instanceof ShipConfig) {
+                throw new InvalidArgumentException('ShipCatalog expects instances of ShipConfig.');
+            }
+
+            $key = $config->getKey();
+
             $definition = new ShipDefinition(
                 $key,
-                $data['label'],
-                $data['category'] ?? 'Divers',
-                $data['role'] ?? '',
-                $data['description'] ?? '',
-                $data['base_cost'] ?? [],
-                (int) ($data['build_time'] ?? 0),
-                $data['stats'] ?? [],
-                $data['requires_research'] ?? [],
-                $data['image'] ?? ''
+                $config->getLabel(),
+                $config->getCategory(),
+                $config->getRole(),
+                $config->getDescription(),
+                $config->getBaseCost(),
+                $config->getBuildTime(),
+                $config->getStats(),
+                $config->getRequiresResearch(),
+                $config->getImage() ?? ''
             );
 
             $this->definitions[$key] = $definition;

--- a/src/Infrastructure/Config/BalanceConfigLoader.php
+++ b/src/Infrastructure/Config/BalanceConfigLoader.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Infrastructure\Config;
+
+use RuntimeException;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+final class BalanceConfigLoader
+{
+    private string $configDir;
+
+    private ?BalanceGlobals $globals = null;
+
+    /** @var array<string, BuildingConfig>|null */
+    private ?array $buildingConfigs = null;
+
+    /** @var array<string, ShipConfig>|null */
+    private ?array $shipConfigs = null;
+
+    /** @var array<string, TechnologyConfig>|null */
+    private ?array $technologyConfigs = null;
+
+    public function __construct(?string $configDir = null)
+    {
+        $defaultDir = dirname(__DIR__, 2) . '/../config/balance';
+        $this->configDir = rtrim($configDir ?? $defaultDir, '/\\');
+    }
+
+    public function getGlobals(): BalanceGlobals
+    {
+        if ($this->globals === null) {
+            $data = $this->parseFile('globals.yml');
+            $initialResources = [];
+            $initialCapacities = [];
+
+            if (isset($data['initial_resources']) && is_array($data['initial_resources'])) {
+                $initialResources = $data['initial_resources'];
+            }
+
+            if (isset($data['initial_capacities']) && is_array($data['initial_capacities'])) {
+                $initialCapacities = $data['initial_capacities'];
+            }
+
+            $this->globals = new BalanceGlobals($initialResources, $initialCapacities);
+        }
+
+        return $this->globals;
+    }
+
+    /**
+     * @return BuildingConfig[]
+     */
+    public function getBuildingConfigs(): array
+    {
+        $this->loadBuildings();
+
+        return array_values($this->buildingConfigs);
+    }
+
+    public function getBuildingConfig(string $key): BuildingConfig
+    {
+        $this->loadBuildings();
+
+        if (!isset($this->buildingConfigs[$key])) {
+            throw new RuntimeException(sprintf('Unknown building configuration "%s".', $key));
+        }
+
+        return $this->buildingConfigs[$key];
+    }
+
+    /**
+     * @return ShipConfig[]
+     */
+    public function getShipConfigs(): array
+    {
+        $this->loadShips();
+
+        return array_values($this->shipConfigs);
+    }
+
+    public function getShipConfig(string $key): ShipConfig
+    {
+        $this->loadShips();
+
+        if (!isset($this->shipConfigs[$key])) {
+            throw new RuntimeException(sprintf('Unknown ship configuration "%s".', $key));
+        }
+
+        return $this->shipConfigs[$key];
+    }
+
+    /**
+     * @return TechnologyConfig[]
+     */
+    public function getTechnologyConfigs(): array
+    {
+        $this->loadTechnologies();
+
+        return array_values($this->technologyConfigs);
+    }
+
+    public function getTechnologyConfig(string $key): TechnologyConfig
+    {
+        $this->loadTechnologies();
+
+        if (!isset($this->technologyConfigs[$key])) {
+            throw new RuntimeException(sprintf('Unknown technology configuration "%s".', $key));
+        }
+
+        return $this->technologyConfigs[$key];
+    }
+
+    private function loadBuildings(): void
+    {
+        if ($this->buildingConfigs !== null) {
+            return;
+        }
+
+        $data = $this->parseFile('buildings.yml');
+        $configs = [];
+
+        foreach ($data as $key => $config) {
+            if (!is_string($key) || !is_array($config)) {
+                throw new RuntimeException('Invalid building configuration entry encountered.');
+            }
+
+            $configs[$key] = new BuildingConfig($key, $config);
+        }
+
+        $this->buildingConfigs = $configs;
+    }
+
+    private function loadShips(): void
+    {
+        if ($this->shipConfigs !== null) {
+            return;
+        }
+
+        $data = $this->parseFile('ships.yml');
+        $configs = [];
+
+        foreach ($data as $key => $config) {
+            if (!is_string($key) || !is_array($config)) {
+                throw new RuntimeException('Invalid ship configuration entry encountered.');
+            }
+
+            $configs[$key] = new ShipConfig($key, $config);
+        }
+
+        $this->shipConfigs = $configs;
+    }
+
+    private function loadTechnologies(): void
+    {
+        if ($this->technologyConfigs !== null) {
+            return;
+        }
+
+        $data = $this->parseFile('technologies.yml');
+        $configs = [];
+
+        foreach ($data as $key => $config) {
+            if (!is_string($key) || !is_array($config)) {
+                throw new RuntimeException('Invalid technology configuration entry encountered.');
+            }
+
+            $configs[$key] = new TechnologyConfig($key, $config);
+        }
+
+        $this->technologyConfigs = $configs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseFile(string $filename): array
+    {
+        $path = $this->configDir . '/' . ltrim($filename, '/');
+
+        if (!is_file($path)) {
+            throw new RuntimeException(sprintf('Balance configuration file "%s" not found.', $path));
+        }
+
+        try {
+            $parsed = Yaml::parseFile($path);
+        } catch (ParseException $exception) {
+            throw new RuntimeException(sprintf('Unable to parse balance configuration file "%s".', $path), 0, $exception);
+        }
+
+        if (!is_array($parsed)) {
+            throw new RuntimeException(sprintf('Balance configuration file "%s" must contain an array structure.', $path));
+        }
+
+        return $parsed;
+    }
+}

--- a/src/Infrastructure/Config/BalanceGlobals.php
+++ b/src/Infrastructure/Config/BalanceGlobals.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Infrastructure\Config;
+
+final class BalanceGlobals
+{
+    /** @var array<string, int> */
+    private array $initialResources = [];
+
+    /** @var array<string, int> */
+    private array $initialCapacities = [];
+
+    /**
+     * @param array<string, int|float> $initialResources
+     * @param array<string, int|float> $initialCapacities
+     */
+    public function __construct(array $initialResources = [], array $initialCapacities = [])
+    {
+        foreach ($initialResources as $resource => $value) {
+            $this->initialResources[$resource] = (int) round((float) $value);
+        }
+
+        foreach ($initialCapacities as $resource => $value) {
+            $this->initialCapacities[$resource] = (int) round((float) $value);
+        }
+    }
+
+    /** @return array<string, int> */
+    public function getInitialResources(): array
+    {
+        return $this->initialResources;
+    }
+
+    public function getInitialResource(string $resource): int
+    {
+        return $this->initialResources[$resource] ?? 0;
+    }
+
+    /** @return array<string, int> */
+    public function getInitialCapacities(): array
+    {
+        return $this->initialCapacities;
+    }
+
+    public function getInitialCapacity(string $resource): int
+    {
+        return $this->initialCapacities[$resource] ?? 0;
+    }
+}

--- a/src/Infrastructure/Config/BuildingConfig.php
+++ b/src/Infrastructure/Config/BuildingConfig.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace App\Infrastructure\Config;
+
+use InvalidArgumentException;
+
+final class BuildingConfig
+{
+    private string $key;
+
+    private string $label;
+
+    /** @var array<string, int> */
+    private array $baseCost = [];
+
+    private float $growthCost = 1.0;
+
+    private int $baseTime = 0;
+
+    private float $growthTime = 1.0;
+
+    private int $productionBase = 0;
+
+    private float $productionGrowth = 1.0;
+
+    private int $energyUseBase = 0;
+
+    private float $energyUseGrowth = 1.0;
+
+    private bool $energyUseLinear = false;
+
+    private string $affects = '';
+
+    /** @var array<string, int> */
+    private array $requiredBuildings = [];
+
+    /** @var array<string, int> */
+    private array $requiredResearch = [];
+
+    private ?string $image = null;
+
+    /** @var array{base?: float, per_level?: float, growth?: float, linear?: bool, max?: float} */
+    private array $shipBuildSpeedBonus = [];
+
+    /** @var array{base?: float, per_level?: float, growth?: float, linear?: bool, max?: float} */
+    private array $researchSpeedBonus = [];
+
+    /** @var array<string, array{base: float, growth: float}> */
+    private array $storage = [];
+
+    /** @var array<string, array{base: float, growth: float, linear?: bool}> */
+    private array $upkeep = [];
+
+    /** @var array{base?: float, per_level?: float, growth?: float, linear?: bool, max?: float} */
+    private array $constructionSpeedBonus = [];
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(string $key, array $data)
+    {
+        $this->key = $key;
+        $this->label = (string) ($data['label'] ?? $key);
+
+        $baseCost = $data['base_cost'] ?? [];
+        if (!is_array($baseCost)) {
+            throw new InvalidArgumentException(sprintf('Invalid base_cost definition for building "%s".', $key));
+        }
+
+        foreach ($baseCost as $resource => $value) {
+            $this->baseCost[$resource] = (int) round((float) $value);
+        }
+
+        $this->growthCost = (float) ($data['growth_cost'] ?? 1.0);
+        $this->baseTime = (int) round((float) ($data['base_time'] ?? 0));
+        $this->growthTime = (float) ($data['growth_time'] ?? 1.0);
+        $this->productionBase = (int) round((float) ($data['prod_base'] ?? 0));
+        $this->productionGrowth = (float) ($data['prod_growth'] ?? 1.0);
+        $this->energyUseBase = (int) round((float) ($data['energy_use_base'] ?? 0));
+        $this->energyUseGrowth = (float) ($data['energy_use_growth'] ?? 1.0);
+        $this->energyUseLinear = !empty($data['energy_use_linear']);
+        $this->affects = (string) ($data['affects'] ?? '');
+
+        if (!empty($data['image'])) {
+            $this->image = (string) $data['image'];
+        }
+
+        $requires = $data['requires'] ?? [];
+        if (!is_array($requires)) {
+            throw new InvalidArgumentException(sprintf('Invalid requires definition for building "%s".', $key));
+        }
+
+        if (!empty($requires['buildings']) && is_array($requires['buildings'])) {
+            foreach ($requires['buildings'] as $buildingKey => $level) {
+                $this->requiredBuildings[$buildingKey] = max(0, (int) $level);
+            }
+        }
+
+        if (!empty($requires['research']) && is_array($requires['research'])) {
+            foreach ($requires['research'] as $researchKey => $level) {
+                $this->requiredResearch[$researchKey] = max(0, (int) $level);
+            }
+        }
+
+        $this->shipBuildSpeedBonus = $this->normalizeBonusConfig($data['ship_build_speed_bonus'] ?? null);
+        $this->researchSpeedBonus = $this->normalizeBonusConfig($data['research_speed_bonus'] ?? null);
+        $this->constructionSpeedBonus = $this->normalizeBonusConfig($data['construction_speed_bonus'] ?? null);
+
+        $storageConfig = $data['storage'] ?? [];
+        if (is_array($storageConfig)) {
+            foreach ($storageConfig as $resourceKey => $config) {
+                if (!is_array($config)) {
+                    continue;
+                }
+
+                $this->storage[$resourceKey] = [
+                    'base' => (float) ($config['base'] ?? 0.0),
+                    'growth' => (float) ($config['growth'] ?? 1.0),
+                ];
+            }
+        }
+
+        $upkeepConfig = $data['upkeep'] ?? [];
+        if (is_array($upkeepConfig)) {
+            foreach ($upkeepConfig as $resourceKey => $config) {
+                if (!is_array($config)) {
+                    continue;
+                }
+
+                $normalized = [
+                    'base' => (float) ($config['base'] ?? 0.0),
+                    'growth' => (float) ($config['growth'] ?? 1.0),
+                ];
+
+                if (!empty($config['linear'])) {
+                    $normalized['linear'] = true;
+                }
+
+                $this->upkeep[$resourceKey] = $normalized;
+            }
+        }
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    /** @return array<string, int> */
+    public function getBaseCost(): array
+    {
+        return $this->baseCost;
+    }
+
+    public function getGrowthCost(): float
+    {
+        return $this->growthCost;
+    }
+
+    public function getBaseTime(): int
+    {
+        return $this->baseTime;
+    }
+
+    public function getGrowthTime(): float
+    {
+        return $this->growthTime;
+    }
+
+    public function getProductionBase(): int
+    {
+        return $this->productionBase;
+    }
+
+    public function getProductionGrowth(): float
+    {
+        return $this->productionGrowth;
+    }
+
+    public function getEnergyUseBase(): int
+    {
+        return $this->energyUseBase;
+    }
+
+    public function getEnergyUseGrowth(): float
+    {
+        return $this->energyUseGrowth;
+    }
+
+    public function isEnergyUseLinear(): bool
+    {
+        return $this->energyUseLinear;
+    }
+
+    public function getAffects(): string
+    {
+        return $this->affects;
+    }
+
+    /**
+     * @return array{buildings: array<string, int>, research: array<string, int>}
+     */
+    public function getRequirements(): array
+    {
+        return [
+            'buildings' => $this->requiredBuildings,
+            'research' => $this->requiredResearch,
+        ];
+    }
+
+    /** @return array<string, int> */
+    public function getRequiredBuildings(): array
+    {
+        return $this->requiredBuildings;
+    }
+
+    /** @return array<string, int> */
+    public function getRequiredResearch(): array
+    {
+        return $this->requiredResearch;
+    }
+
+    public function getImage(): ?string
+    {
+        return $this->image;
+    }
+
+    /**
+     * @return array{base?: float, per_level?: float, growth?: float, linear?: bool, max?: float}
+     */
+    public function getShipBuildSpeedBonus(): array
+    {
+        return $this->shipBuildSpeedBonus;
+    }
+
+    /**
+     * @return array{base?: float, per_level?: float, growth?: float, linear?: bool, max?: float}
+     */
+    public function getResearchSpeedBonus(): array
+    {
+        return $this->researchSpeedBonus;
+    }
+
+    /**
+     * @return array<string, array{base: float, growth: float}>
+     */
+    public function getStorage(): array
+    {
+        return $this->storage;
+    }
+
+    /**
+     * @return array<string, array{base: float, growth: float, linear?: bool}>
+     */
+    public function getUpkeep(): array
+    {
+        return $this->upkeep;
+    }
+
+    /**
+     * @return array{base?: float, per_level?: float, growth?: float, linear?: bool, max?: float}
+     */
+    public function getConstructionSpeedBonus(): array
+    {
+        return $this->constructionSpeedBonus;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return array{base?: float, per_level?: float, growth?: float, linear?: bool, max?: float}
+     */
+    private function normalizeBonusConfig(mixed $value): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        if (!is_array($value)) {
+            $numeric = (float) $value;
+            if ($numeric === 0.0) {
+                return [];
+            }
+
+            return ['base' => $numeric];
+        }
+
+        $normalized = [];
+
+        if (array_key_exists('base', $value)) {
+            $normalized['base'] = (float) $value['base'];
+        }
+
+        if (array_key_exists('per_level', $value)) {
+            $normalized['per_level'] = (float) $value['per_level'];
+        }
+
+        if (array_key_exists('growth', $value)) {
+            $normalized['growth'] = (float) $value['growth'];
+        }
+
+        if (!empty($value['linear'])) {
+            $normalized['linear'] = true;
+        }
+
+        if (array_key_exists('max', $value)) {
+            $normalized['max'] = (float) $value['max'];
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Infrastructure/Config/ShipConfig.php
+++ b/src/Infrastructure/Config/ShipConfig.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Infrastructure\Config;
+
+use InvalidArgumentException;
+
+final class ShipConfig
+{
+    private string $key;
+
+    private string $label;
+
+    private string $category;
+
+    private string $role;
+
+    private string $description;
+
+    /** @var array<string, int> */
+    private array $baseCost = [];
+
+    private int $buildTime = 0;
+
+    /** @var array<string, int> */
+    private array $stats = [];
+
+    /** @var array<string, int> */
+    private array $requiresResearch = [];
+
+    private ?string $image = null;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(string $key, array $data)
+    {
+        $this->key = $key;
+        $this->label = (string) ($data['label'] ?? $key);
+        $this->category = (string) ($data['category'] ?? 'Divers');
+        $this->role = (string) ($data['role'] ?? '');
+        $this->description = (string) ($data['description'] ?? '');
+
+        $baseCost = $data['base_cost'] ?? [];
+        if (!is_array($baseCost)) {
+            throw new InvalidArgumentException(sprintf('Invalid base_cost definition for ship "%s".', $key));
+        }
+
+        foreach ($baseCost as $resource => $value) {
+            $this->baseCost[$resource] = (int) round((float) $value);
+        }
+
+        $this->buildTime = (int) round((float) ($data['build_time'] ?? 0));
+
+        $stats = $data['stats'] ?? [];
+        if (!is_array($stats)) {
+            throw new InvalidArgumentException(sprintf('Invalid stats definition for ship "%s".', $key));
+        }
+
+        foreach ($stats as $statKey => $value) {
+            $this->stats[$statKey] = (int) round((float) $value);
+        }
+
+        $requiresResearch = $data['requires_research'] ?? [];
+        if (!is_array($requiresResearch)) {
+            throw new InvalidArgumentException(sprintf('Invalid requires_research definition for ship "%s".', $key));
+        }
+
+        foreach ($requiresResearch as $researchKey => $level) {
+            $this->requiresResearch[$researchKey] = max(0, (int) $level);
+        }
+
+        if (!empty($data['image'])) {
+            $this->image = (string) $data['image'];
+        }
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /** @return array<string, int> */
+    public function getBaseCost(): array
+    {
+        return $this->baseCost;
+    }
+
+    public function getBuildTime(): int
+    {
+        return $this->buildTime;
+    }
+
+    /** @return array<string, int> */
+    public function getStats(): array
+    {
+        return $this->stats;
+    }
+
+    /** @return array<string, int> */
+    public function getRequiresResearch(): array
+    {
+        return $this->requiresResearch;
+    }
+
+    public function getImage(): ?string
+    {
+        return $this->image;
+    }
+}

--- a/src/Infrastructure/Config/TechnologyConfig.php
+++ b/src/Infrastructure/Config/TechnologyConfig.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Infrastructure\Config;
+
+use InvalidArgumentException;
+
+final class TechnologyConfig
+{
+    private string $key;
+
+    private string $label;
+
+    private string $category;
+
+    private string $description;
+
+    /** @var array<string, int> */
+    private array $baseCost = [];
+
+    private int $baseTime = 0;
+
+    private float $growthCost = 1.0;
+
+    private float $growthTime = 1.0;
+
+    private int $maxLevel = 1;
+
+    /** @var array<string, int> */
+    private array $requires = [];
+
+    private int $requiresLab = 0;
+
+    private ?string $image = null;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(string $key, array $data)
+    {
+        $this->key = $key;
+        $this->label = (string) ($data['label'] ?? $key);
+        $this->category = (string) ($data['category'] ?? 'Divers');
+        $this->description = (string) ($data['description'] ?? '');
+
+        $baseCost = $data['base_cost'] ?? [];
+        if (!is_array($baseCost)) {
+            throw new InvalidArgumentException(sprintf('Invalid base_cost definition for technology "%s".', $key));
+        }
+
+        foreach ($baseCost as $resource => $value) {
+            $this->baseCost[$resource] = (int) round((float) $value);
+        }
+
+        $this->baseTime = (int) round((float) ($data['base_time'] ?? 0));
+        $this->growthCost = (float) ($data['growth_cost'] ?? 1.0);
+        $this->growthTime = (float) ($data['growth_time'] ?? 1.0);
+        $this->maxLevel = max(0, (int) ($data['max_level'] ?? 10));
+
+        $requires = $data['requires'] ?? [];
+        if (!is_array($requires)) {
+            throw new InvalidArgumentException(sprintf('Invalid requires definition for technology "%s".', $key));
+        }
+
+        foreach ($requires as $researchKey => $level) {
+            $this->requires[$researchKey] = max(0, (int) $level);
+        }
+
+        $this->requiresLab = max(0, (int) ($data['requires_lab'] ?? 0));
+
+        if (!empty($data['image'])) {
+            $this->image = (string) $data['image'];
+        }
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /** @return array<string, int> */
+    public function getBaseCost(): array
+    {
+        return $this->baseCost;
+    }
+
+    public function getBaseTime(): int
+    {
+        return $this->baseTime;
+    }
+
+    public function getGrowthCost(): float
+    {
+        return $this->growthCost;
+    }
+
+    public function getGrowthTime(): float
+    {
+        return $this->growthTime;
+    }
+
+    public function getMaxLevel(): int
+    {
+        return $this->maxLevel;
+    }
+
+    /** @return array<string, int> */
+    public function getRequires(): array
+    {
+        return $this->requires;
+    }
+
+    public function getRequiresLab(): int
+    {
+        return $this->requiresLab;
+    }
+
+    public function getImage(): ?string
+    {
+        return $this->image;
+    }
+}

--- a/tests/Integration/QueueProcessingTest.php
+++ b/tests/Integration/QueueProcessingTest.php
@@ -27,6 +27,9 @@ use App\Domain\Service\ResearchCatalog;
 use App\Domain\Service\ResourceEffectFactory;
 use App\Domain\Service\ResourceTickService;
 use App\Domain\Service\ShipCatalog;
+use App\Infrastructure\Config\BuildingConfig;
+use App\Infrastructure\Config\ShipConfig;
+use App\Infrastructure\Config\TechnologyConfig;
 use App\Infrastructure\Http\Request;
 use App\Infrastructure\Http\Session\FlashBag;
 use App\Infrastructure\Http\Session\Session;
@@ -46,7 +49,7 @@ class QueueProcessingTest extends TestCase
             1 => ['metal_mine' => 0, 'research_lab' => 2, 'shipyard' => 1],
         ]);
         $buildQueue = new InMemoryBuildQueueRepository();
-        $catalog = new BuildingCatalog([
+        $catalog = new BuildingCatalog($this->makeBuildingConfigs([
             'metal_mine' => [
                 'label' => 'Mine de métal',
                 'base_cost' => ['metal' => 100],
@@ -60,7 +63,7 @@ class QueueProcessingTest extends TestCase
                 'energy_use_linear' => false,
                 'affects' => 'metal',
             ],
-        ]);
+        ]));
         $calculator = new BuildingCalculator($catalog);
 
         $playerStats = new InMemoryPlayerStatsRepository();
@@ -102,7 +105,7 @@ class QueueProcessingTest extends TestCase
             1 => ['propulsion_basic' => 0],
         ]);
         $researchQueue = new InMemoryResearchQueueRepository();
-        $catalog = new ResearchCatalog([
+        $catalog = new ResearchCatalog($this->makeTechnologyConfigs([
             'propulsion_basic' => [
                 'label' => 'Propulsion spatiale',
                 'category' => 'Propulsion',
@@ -116,7 +119,7 @@ class QueueProcessingTest extends TestCase
                 'requires_lab' => 1,
                 'image' => '',
             ],
-        ]);
+        ]));
         $calculator = new ResearchCalculator(0.1);
 
         $playerStats = new InMemoryPlayerStatsRepository();
@@ -150,7 +153,7 @@ class QueueProcessingTest extends TestCase
         ]);
         $shipQueue = new InMemoryShipBuildQueueRepository();
         $fleetRepository = new InMemoryFleetRepository();
-        $buildingCatalog = new BuildingCatalog([
+        $buildingCatalog = new BuildingCatalog($this->makeBuildingConfigs([
             'shipyard' => [
                 'label' => 'Chantier',
                 'base_cost' => ['metal' => 100],
@@ -165,9 +168,9 @@ class QueueProcessingTest extends TestCase
                 'affects' => 'energy',
                 'ship_build_speed_bonus' => ['base' => 0.1, 'linear' => true, 'max' => 0.9],
             ],
-        ]);
+        ]));
         $buildingCalculator = new BuildingCalculator();
-        $catalog = new ShipCatalog([
+        $catalog = new ShipCatalog($this->makeShipConfigs([
             'fighter' => [
                 'label' => 'Chasseur',
                 'category' => 'Escadre',
@@ -179,7 +182,7 @@ class QueueProcessingTest extends TestCase
                 'requires_research' => [],
                 'image' => '',
             ],
-        ]);
+        ]));
 
         $playerStats = new InMemoryPlayerStatsRepository();
         $useCase = new BuildShips($planetRepository, $buildingStates, $researchStates, $shipQueue, $playerStats, $buildingCatalog, $buildingCalculator, $catalog);
@@ -213,7 +216,7 @@ class QueueProcessingTest extends TestCase
         ]);
         $shipQueue = new InMemoryShipBuildQueueRepository();
         $fleetRepository = new InMemoryFleetRepository();
-        $buildingCatalog = new BuildingCatalog([
+        $buildingCatalog = new BuildingCatalog($this->makeBuildingConfigs([
             'shipyard' => [
                 'label' => 'Chantier',
                 'base_cost' => ['metal' => 100],
@@ -228,9 +231,9 @@ class QueueProcessingTest extends TestCase
                 'affects' => 'energy',
                 'ship_build_speed_bonus' => ['base' => 0.1, 'linear' => true, 'max' => 0.9],
             ],
-        ]);
+        ]));
         $buildingCalculator = new BuildingCalculator();
-        $catalog = new ShipCatalog([
+        $catalog = new ShipCatalog($this->makeShipConfigs([
             'probe' => [
                 'label' => 'Sonde',
                 'category' => 'Divers',
@@ -242,7 +245,7 @@ class QueueProcessingTest extends TestCase
                 'requires_research' => [],
                 'image' => '',
             ],
-        ]);
+        ]));
 
         $playerStats = new InMemoryPlayerStatsRepository();
         $buildShips = new BuildShips($planetRepository, $buildingStates, $researchStates, $shipQueue, $playerStats, $buildingCatalog, $buildingCalculator, $catalog);
@@ -266,7 +269,7 @@ class QueueProcessingTest extends TestCase
         ]);
         $shipQueue = new InMemoryShipBuildQueueRepository();
         $fleetRepository = new InMemoryFleetRepository();
-        $buildingCatalog = new BuildingCatalog([
+        $buildingCatalog = new BuildingCatalog($this->makeBuildingConfigs([
             'shipyard' => [
                 'label' => 'Chantier',
                 'base_cost' => ['metal' => 100],
@@ -281,9 +284,9 @@ class QueueProcessingTest extends TestCase
                 'affects' => 'energy',
                 'ship_build_speed_bonus' => ['base' => 0.1, 'linear' => true, 'max' => 0.9],
             ],
-        ]);
+        ]));
         $buildingCalculator = new BuildingCalculator();
-        $catalog = new ShipCatalog([
+        $catalog = new ShipCatalog($this->makeShipConfigs([
             'fighter' => [
                 'label' => 'Chasseur',
                 'category' => 'Escadre',
@@ -295,7 +298,7 @@ class QueueProcessingTest extends TestCase
                 'requires_research' => [],
                 'image' => '',
             ],
-        ]);
+        ]));
         $queueProcessor = new ProcessShipBuildQueue($shipQueue, $fleetRepository);
 
         $overviewUseCase = new GetShipyardOverview(
@@ -348,7 +351,7 @@ class QueueProcessingTest extends TestCase
         $researchStates = new InMemoryResearchStateRepository([
             1 => [],
         ]);
-        $catalog = new BuildingCatalog([
+        $catalog = new BuildingCatalog($this->makeBuildingConfigs([
             'metal_mine' => [
                 'label' => 'Mine de métal',
                 'base_cost' => ['metal' => 100],
@@ -362,7 +365,7 @@ class QueueProcessingTest extends TestCase
                 'energy_use_linear' => false,
                 'affects' => 'metal',
             ],
-        ]);
+        ]));
         $calculator = new BuildingCalculator($catalog);
 
         $useCase = new UpgradeBuilding($planetRepository, $buildingStates, $buildQueue, $playerStats, $researchStates, $catalog, $calculator);
@@ -393,7 +396,7 @@ class QueueProcessingTest extends TestCase
         $researchStates = new InMemoryResearchStateRepository([
             1 => [],
         ]);
-        $catalog = new BuildingCatalog([
+        $catalog = new BuildingCatalog($this->makeBuildingConfigs([
             'metal_mine' => [
                 'label' => 'Mine de métal',
                 'base_cost' => ['metal' => 50],
@@ -407,7 +410,7 @@ class QueueProcessingTest extends TestCase
                 'energy_use_linear' => false,
                 'affects' => 'metal',
             ],
-        ]);
+        ]));
         $calculator = new BuildingCalculator($catalog);
 
         $useCase = new UpgradeBuilding($planetRepository, $buildingStates, $buildQueue, $playerStats, $researchStates, $catalog, $calculator);
@@ -435,7 +438,7 @@ class QueueProcessingTest extends TestCase
         $researchStates = new InMemoryResearchStateRepository([
             1 => [],
         ]);
-        $catalog = new BuildingCatalog([
+        $catalog = new BuildingCatalog($this->makeBuildingConfigs([
             'metal_mine' => [
                 'label' => 'Mine de métal',
                 'base_cost' => ['metal' => 100],
@@ -449,7 +452,7 @@ class QueueProcessingTest extends TestCase
                 'energy_use_linear' => false,
                 'affects' => 'metal',
             ],
-        ]);
+        ]));
         $calculator = new BuildingCalculator($catalog);
         $useCase = new UpgradeBuilding($planetRepository, $buildingStates, $buildQueue, $playerStats, $researchStates, $catalog, $calculator);
         $processor = new ProcessBuildQueue($buildQueue, $buildingStates, $planetRepository, $catalog, $calculator);
@@ -479,7 +482,7 @@ class QueueProcessingTest extends TestCase
         ]);
         $researchQueue = new InMemoryResearchQueueRepository();
         $playerStats = new InMemoryPlayerStatsRepository();
-        $catalog = new ResearchCatalog([
+        $catalog = new ResearchCatalog($this->makeTechnologyConfigs([
             'propulsion_basic' => [
                 'label' => 'Propulsion spatiale',
                 'category' => 'Propulsion',
@@ -493,7 +496,7 @@ class QueueProcessingTest extends TestCase
                 'requires_lab' => 1,
                 'image' => '',
             ],
-        ]);
+        ]));
         $calculator = new ResearchCalculator(0.1);
         $useCase = new StartResearch($planetRepository, $buildingStates, $researchStates, $researchQueue, $playerStats, $catalog, $calculator);
 
@@ -521,7 +524,7 @@ class QueueProcessingTest extends TestCase
         ]);
         $researchQueue = new InMemoryResearchQueueRepository();
         $playerStats = new InMemoryPlayerStatsRepository();
-        $catalog = new ResearchCatalog([
+        $catalog = new ResearchCatalog($this->makeTechnologyConfigs([
             'propulsion_basic' => [
                 'label' => 'Propulsion spatiale',
                 'category' => 'Propulsion',
@@ -535,7 +538,7 @@ class QueueProcessingTest extends TestCase
                 'requires_lab' => 1,
                 'image' => '',
             ],
-        ]);
+        ]));
         $calculator = new ResearchCalculator(0.1);
         $useCase = new StartResearch($planetRepository, $buildingStates, $researchStates, $researchQueue, $playerStats, $catalog, $calculator);
 
@@ -587,7 +590,7 @@ class QueueProcessingTest extends TestCase
             ],
         ];
 
-        $resourceTick = new ResourceTickService(ResourceEffectFactory::fromBuildingConfig($buildingConfig));
+        $resourceTick = new ResourceTickService(ResourceEffectFactory::fromBuildingConfig($this->makeBuildingConfigs($buildingConfig)));
 
         $sessionStorage = ['user_id' => 5];
         $session = new Session($sessionStorage);
@@ -661,7 +664,7 @@ class QueueProcessingTest extends TestCase
             ],
         ];
 
-        $resourceTick = new ResourceTickService(ResourceEffectFactory::fromBuildingConfig($buildingConfig));
+        $resourceTick = new ResourceTickService(ResourceEffectFactory::fromBuildingConfig($this->makeBuildingConfigs($buildingConfig)));
 
         $sessionStorage = ['user_id' => 5];
         $session = new Session($sessionStorage);
@@ -717,7 +720,7 @@ class QueueProcessingTest extends TestCase
         ]);
         $shipQueue = new InMemoryShipBuildQueueRepository();
         $fleetRepository = new InMemoryFleetRepository();
-        $buildingCatalog = new BuildingCatalog([
+        $buildingCatalog = new BuildingCatalog($this->makeBuildingConfigs([
             'shipyard' => [
                 'label' => 'Chantier',
                 'base_cost' => ['metal' => 100],
@@ -732,9 +735,9 @@ class QueueProcessingTest extends TestCase
                 'affects' => 'energy',
                 'ship_build_speed_bonus' => ['base' => 0.1, 'linear' => true, 'max' => 0.9],
             ],
-        ]);
+        ]));
         $buildingCalculator = new BuildingCalculator();
-        $catalog = new ShipCatalog([
+        $catalog = new ShipCatalog($this->makeShipConfigs([
             'fighter' => [
                 'label' => 'Chasseur',
                 'category' => 'Escadre',
@@ -746,7 +749,7 @@ class QueueProcessingTest extends TestCase
                 'requires_research' => [],
                 'image' => '',
             ],
-        ]);
+        ]));
 
         $playerStats = new InMemoryPlayerStatsRepository();
         $buildShips = new BuildShips($planetRepository, $buildingStates, $researchStates, $shipQueue, $playerStats, $buildingCatalog, $buildingCalculator, $catalog);
@@ -773,6 +776,51 @@ class QueueProcessingTest extends TestCase
         self::assertSame(12000, $plan['speed']);
         self::assertSame(36, $plan['travel_time']);
         self::assertSame(144, $plan['fuel']);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $config
+     *
+     * @return BuildingConfig[]
+     */
+    private function makeBuildingConfigs(array $config): array
+    {
+        $result = [];
+        foreach ($config as $key => $data) {
+            $result[] = new BuildingConfig($key, $data);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $config
+     *
+     * @return TechnologyConfig[]
+     */
+    private function makeTechnologyConfigs(array $config): array
+    {
+        $result = [];
+        foreach ($config as $key => $data) {
+            $result[] = new TechnologyConfig($key, $data);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $config
+     *
+     * @return ShipConfig[]
+     */
+    private function makeShipConfigs(array $config): array
+    {
+        $result = [];
+        foreach ($config as $key => $data) {
+            $result[] = new ShipConfig($key, $data);
+        }
+
+        return $result;
     }
 }
 

--- a/tests/Unit/BuildingCalculatorTest.php
+++ b/tests/Unit/BuildingCalculatorTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit;
 use App\Domain\Entity\BuildingDefinition;
 use App\Domain\Service\BuildingCalculator;
 use App\Domain\Service\BuildingCatalog;
+use App\Infrastructure\Config\BuildingConfig;
 use PHPUnit\Framework\TestCase;
 
 class BuildingCalculatorTest extends TestCase
@@ -89,7 +90,12 @@ class BuildingCalculatorTest extends TestCase
             ],
         ];
 
-        $this->catalog = new BuildingCatalog($config);
+        $buildingConfigs = [];
+        foreach ($config as $key => $data) {
+            $buildingConfigs[] = new BuildingConfig($key, $data);
+        }
+
+        $this->catalog = new BuildingCatalog($buildingConfigs);
         $this->calculator = new BuildingCalculator($this->catalog);
         $this->definition = $this->catalog->get('metal_mine');
     }


### PR DESCRIPTION
## Summary
- add symfony/yaml and migrate balance data into config/balance YAML files
- introduce BalanceConfigLoader and DTOs for buildings, ships, technologies and globals
- update service wiring, catalogs, resource effects and tests to consume the new DTOs

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cfccde295083329b82ed6cd8b0cbc1