### PR TITLE
Introduce balance configuration for resource processing

### DIFF
--- a/config/game/balance.php
+++ b/config/game/balance.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'minimum_speed_modifier' => 0.01,
+    'maximum_discount' => 0.95,
+    'tick_duration_seconds' => 3600,
+    'rounding_tolerance' => 0.000001,
+    'rounding' => [
+        'resources' => 'floor',
+        'capacities' => 'round',
+        'production' => 'round',
+        'energy' => [
+            'stats' => 'round',
+            'available' => 'floor',
+        ],
+    ],
+];

--- a/src/Domain/Config/BalanceConfig.php
+++ b/src/Domain/Config/BalanceConfig.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Domain\Config;
+
+final class BalanceConfig
+{
+    private float $minimumSpeedModifier;
+
+    private float $maximumDiscount;
+
+    private int $tickDurationSeconds;
+
+    private BalanceRoundingConfig $rounding;
+
+    public function __construct(
+        float $minimumSpeedModifier = 0.01,
+        float $maximumDiscount = 0.95,
+        int $tickDurationSeconds = 3600,
+        ?BalanceRoundingConfig $rounding = null,
+    ) {
+        $this->minimumSpeedModifier = max(0.0, $minimumSpeedModifier);
+        $this->maximumDiscount = max(0.0, min(1.0, $maximumDiscount));
+        $this->tickDurationSeconds = max(1, $tickDurationSeconds);
+        $this->rounding = $rounding ?? new BalanceRoundingConfig();
+    }
+
+    public function getMinimumSpeedModifier(): float
+    {
+        return $this->minimumSpeedModifier;
+    }
+
+    public function getMaximumDiscount(): float
+    {
+        return $this->maximumDiscount;
+    }
+
+    public function getTickDurationSeconds(): int
+    {
+        return $this->tickDurationSeconds;
+    }
+
+    public function getRounding(): BalanceRoundingConfig
+    {
+        return $this->rounding;
+    }
+
+    public function getRoundingTolerance(): float
+    {
+        return $this->rounding->getTolerance();
+    }
+
+    public function roundResourceQuantity(float $value): int
+    {
+        return $this->rounding->roundResource($value);
+    }
+
+    public function roundCapacity(float $value): int
+    {
+        return $this->rounding->roundCapacity($value);
+    }
+
+    public function roundProduction(float $value): int
+    {
+        return $this->rounding->roundProduction($value);
+    }
+
+    public function roundEnergyStat(float $value): int
+    {
+        return $this->rounding->roundEnergyStat($value);
+    }
+
+    public function roundEnergyAvailable(float $value): int
+    {
+        return $this->rounding->roundEnergyAvailable($value);
+    }
+}

--- a/src/Domain/Config/BalanceRoundingConfig.php
+++ b/src/Domain/Config/BalanceRoundingConfig.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Domain\Config;
+
+use InvalidArgumentException;
+
+final class BalanceRoundingConfig
+{
+    public const MODE_FLOOR = 'floor';
+    public const MODE_ROUND = 'round';
+    public const MODE_CEIL = 'ceil';
+
+    private const ALLOWED_MODES = [
+        self::MODE_FLOOR,
+        self::MODE_ROUND,
+        self::MODE_CEIL,
+    ];
+
+    private float $tolerance;
+
+    private string $resourceMode;
+
+    private string $capacityMode;
+
+    private string $productionMode;
+
+    private string $energyStatMode;
+
+    private string $energyAvailableMode;
+
+    public function __construct(
+        float $tolerance = 0.000001,
+        string $resourceMode = self::MODE_FLOOR,
+        string $capacityMode = self::MODE_ROUND,
+        string $productionMode = self::MODE_ROUND,
+        string $energyStatMode = self::MODE_ROUND,
+        string $energyAvailableMode = self::MODE_FLOOR,
+    ) {
+        $this->tolerance = max(0.0, $tolerance);
+        $this->resourceMode = $this->normalizeMode($resourceMode);
+        $this->capacityMode = $this->normalizeMode($capacityMode);
+        $this->productionMode = $this->normalizeMode($productionMode);
+        $this->energyStatMode = $this->normalizeMode($energyStatMode);
+        $this->energyAvailableMode = $this->normalizeMode($energyAvailableMode);
+    }
+
+    public function getTolerance(): float
+    {
+        return $this->tolerance;
+    }
+
+    public function roundResource(float $value): int
+    {
+        return $this->applyMode($this->resourceMode, $value);
+    }
+
+    public function roundCapacity(float $value): int
+    {
+        return $this->applyMode($this->capacityMode, $value);
+    }
+
+    public function roundProduction(float $value): int
+    {
+        return $this->applyMode($this->productionMode, $value);
+    }
+
+    public function roundEnergyStat(float $value): int
+    {
+        return $this->applyMode($this->energyStatMode, $value);
+    }
+
+    public function roundEnergyAvailable(float $value): int
+    {
+        return $this->applyMode($this->energyAvailableMode, $value);
+    }
+
+    private function normalizeMode(string $mode): string
+    {
+        $mode = strtolower($mode);
+
+        if (!in_array($mode, self::ALLOWED_MODES, true)) {
+            throw new InvalidArgumentException(sprintf('Invalid rounding mode "%s".', $mode));
+        }
+
+        return $mode;
+    }
+
+    private function applyMode(string $mode, float $value): int
+    {
+        return match ($mode) {
+            self::MODE_FLOOR => (int) floor($value + $this->tolerance),
+            self::MODE_CEIL => (int) ceil($value - $this->tolerance),
+            default => (int) round($value),
+        };
+    }
+}

--- a/src/Domain/Service/CostService.php
+++ b/src/Domain/Service/CostService.php
@@ -2,8 +2,14 @@
 
 namespace App\Domain\Service;
 
+use App\Domain\Config\BalanceConfig;
+
 class CostService
 {
+    public function __construct(private readonly BalanceConfig $balanceConfig = new BalanceConfig())
+    {
+    }
+
     /**
      * @param array<string, int|float> $baseCost
      *
@@ -44,7 +50,7 @@ class CostService
 
     public function scaledDuration(int $baseDuration, float $growthFactor, int $currentLevel, float $speedModifier = 1.0): int
     {
-        $speedModifier = max(0.01, $speedModifier);
+        $speedModifier = max($this->balanceConfig->getMinimumSpeedModifier(), $speedModifier);
 
         return (int) max(1, round($baseDuration * pow($growthFactor, $currentLevel) / $speedModifier));
     }
@@ -56,7 +62,7 @@ class CostService
      */
     public function applyDiscount(array $cost, float $discount): array
     {
-        $discount = max(0.0, min(0.95, $discount));
+        $discount = max(0.0, min($this->balanceConfig->getMaximumDiscount(), $discount));
 
         $result = [];
         foreach ($cost as $resource => $value) {

--- a/src/Infrastructure/Config/BalanceConfigLoader.php
+++ b/src/Infrastructure/Config/BalanceConfigLoader.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Infrastructure\Config;
+
+use App\Domain\Config\BalanceConfig;
+use App\Domain\Config\BalanceRoundingConfig;
+use InvalidArgumentException;
+use RuntimeException;
+
+final class BalanceConfigLoader
+{
+    public function load(string $path): BalanceConfig
+    {
+        $config = $this->loadFile($path);
+
+        return $this->fromArray($config);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function fromArray(array $config): BalanceConfig
+    {
+        $roundingTolerance = isset($config['rounding_tolerance'])
+            ? (float) $config['rounding_tolerance']
+            : 0.000001;
+
+        $roundingConfig = [];
+        if (isset($config['rounding']) && is_array($config['rounding'])) {
+            $roundingConfig = $config['rounding'];
+        }
+
+        $energyConfig = [];
+        if (isset($roundingConfig['energy']) && is_array($roundingConfig['energy'])) {
+            $energyConfig = $roundingConfig['energy'];
+        }
+
+        $rounding = new BalanceRoundingConfig(
+            $roundingTolerance,
+            $this->extractMode($roundingConfig, ['resources', 'resource'], BalanceRoundingConfig::MODE_FLOOR),
+            $this->extractMode($roundingConfig, ['capacities', 'capacity'], BalanceRoundingConfig::MODE_ROUND),
+            $this->extractMode($roundingConfig, ['production', 'productions'], BalanceRoundingConfig::MODE_ROUND),
+            $this->extractEnergyMode($energyConfig, BalanceRoundingConfig::MODE_ROUND),
+            $this->extractMode($energyConfig, ['available', 'storage'], BalanceRoundingConfig::MODE_FLOOR),
+        );
+
+        $tickDuration = $config['tick_duration_seconds'] ?? $config['tick_duration'] ?? 3600;
+
+        return new BalanceConfig(
+            isset($config['minimum_speed_modifier']) ? (float) $config['minimum_speed_modifier'] : 0.01,
+            isset($config['maximum_discount']) ? (float) $config['maximum_discount'] : 0.95,
+            (int) $tickDuration,
+            $rounding,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadFile(string $path): array
+    {
+        if (!is_file($path)) {
+            throw new InvalidArgumentException(sprintf('Balance configuration file "%s" not found.', $path));
+        }
+
+        $extension = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
+
+        if ($extension === 'php') {
+            $data = require $path;
+        } elseif ($extension === 'yml' || $extension === 'yaml') {
+            if (!function_exists('yaml_parse_file')) {
+                throw new RuntimeException('YAML extension is required to parse balance configuration.');
+            }
+
+            $data = yaml_parse_file($path);
+        } else {
+            throw new InvalidArgumentException(sprintf('Unsupported balance configuration format "%s".', $extension));
+        }
+
+        if (!is_array($data)) {
+            throw new RuntimeException('Balance configuration must return an array.');
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @param string|string[]      $keys
+     */
+    private function extractMode(array $config, string|array $keys, string $default): string
+    {
+        $keys = (array) $keys;
+
+        foreach ($keys as $key) {
+            if (isset($config[$key]) && is_string($config[$key])) {
+                return strtolower($config[$key]);
+            }
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function extractEnergyMode(array $config, string $default): string
+    {
+        if (isset($config['stats'])) {
+            $value = $config['stats'];
+        } elseif (isset($config['production'])) {
+            $value = $config['production'];
+        } elseif (isset($config['consumption'])) {
+            $value = $config['consumption'];
+        } elseif (isset($config['balance'])) {
+            $value = $config['balance'];
+        } else {
+            $value = $default;
+        }
+
+        if (is_string($value)) {
+            return strtolower($value);
+        }
+
+        return $default;
+    }
+}

--- a/tests/Unit/BalanceConfigLoaderTest.php
+++ b/tests/Unit/BalanceConfigLoaderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit;
+
+use App\Infrastructure\Config\BalanceConfigLoader;
+use PHPUnit\Framework\TestCase;
+
+class BalanceConfigLoaderTest extends TestCase
+{
+    public function testFromArrayBuildsBalanceConfig(): void
+    {
+        $loader = new BalanceConfigLoader();
+
+        $config = $loader->fromArray([
+            'minimum_speed_modifier' => 0.05,
+            'maximum_discount' => 0.5,
+            'tick_duration_seconds' => 120,
+            'rounding_tolerance' => 0.0005,
+            'rounding' => [
+                'resources' => 'ceil',
+                'capacities' => 'floor',
+                'production' => 'round',
+                'energy' => [
+                    'stats' => 'ceil',
+                    'available' => 'round',
+                ],
+            ],
+        ]);
+
+        self::assertSame(0.05, $config->getMinimumSpeedModifier());
+        self::assertSame(0.5, $config->getMaximumDiscount());
+        self::assertSame(120, $config->getTickDurationSeconds());
+        self::assertSame(0.0005, $config->getRoundingTolerance());
+        self::assertSame(11, $config->roundResourceQuantity(10.6));
+        self::assertSame(9, $config->roundCapacity(9.4));
+        self::assertSame(11, $config->roundEnergyStat(10.4));
+        self::assertSame(10, $config->roundEnergyAvailable(9.6));
+    }
+
+    public function testFromArrayAppliesDefaultsWhenConfigMissing(): void
+    {
+        $loader = new BalanceConfigLoader();
+
+        $config = $loader->fromArray([]);
+
+        self::assertSame(0.01, $config->getMinimumSpeedModifier());
+        self::assertSame(0.95, $config->getMaximumDiscount());
+        self::assertSame(3600, $config->getTickDurationSeconds());
+        self::assertSame(0.000001, $config->getRoundingTolerance());
+        self::assertSame(10, $config->roundResourceQuantity(10.2));
+        self::assertSame(10, $config->roundCapacity(9.6));
+        self::assertSame(9, $config->roundEnergyAvailable(9.6));
+    }
+
+    public function testInvalidRoundingModeThrowsException(): void
+    {
+        $loader = new BalanceConfigLoader();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $loader->fromArray(['rounding' => ['resources' => 'invalid']]);
+    }
+}

--- a/tests/Unit/ResourceEffectFactoryTest.php
+++ b/tests/Unit/ResourceEffectFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit;
+
+use App\Domain\Service\ResourceEffectFactory;
+use PHPUnit\Framework\TestCase;
+
+class ResourceEffectFactoryTest extends TestCase
+{
+    public function testFactoryProducesEffectsFromYamlLikeConfig(): void
+    {
+        $config = [
+            'metal_mine' => [
+                'affects' => 'metal',
+                'prod_base' => '100',
+                'prod_growth' => '1.15',
+                'energy_use_base' => '10',
+                'energy_use_growth' => '1.1',
+                'energy_use_linear' => true,
+                'storage' => [
+                    'metal' => ['base' => '1000', 'growth' => '1.5'],
+                ],
+                'upkeep' => [
+                    'hydrogen' => ['base' => '5', 'growth' => '1.02', 'linear' => true],
+                ],
+            ],
+            'solar_plant' => [
+                'affects' => 'energy',
+                'prod_base' => '50',
+                'prod_growth' => '1.12',
+                'energy_use_base' => '0',
+                'energy_use_growth' => '1',
+            ],
+        ];
+
+        $effects = ResourceEffectFactory::fromBuildingConfig($config);
+
+        self::assertArrayHasKey('metal_mine', $effects);
+        self::assertSame(100.0, $effects['metal_mine']['produces']['metal']['base']);
+        self::assertSame(1.15, $effects['metal_mine']['produces']['metal']['growth']);
+        self::assertSame(10.0, $effects['metal_mine']['energy']['consumption']['base']);
+        self::assertSame(1.1, $effects['metal_mine']['energy']['consumption']['growth']);
+        self::assertTrue($effects['metal_mine']['energy']['consumption']['linear']);
+        self::assertSame(1000.0, $effects['metal_mine']['storage']['metal']['base']);
+        self::assertSame(1.5, $effects['metal_mine']['storage']['metal']['growth']);
+        self::assertSame(5.0, $effects['metal_mine']['consumes']['hydrogen']['base']);
+        self::assertSame(1.02, $effects['metal_mine']['consumes']['hydrogen']['growth']);
+        self::assertTrue($effects['metal_mine']['consumes']['hydrogen']['linear']);
+
+        self::assertArrayHasKey('solar_plant', $effects);
+        self::assertSame(50.0, $effects['solar_plant']['energy']['production']['base']);
+        self::assertSame(1.12, $effects['solar_plant']['energy']['production']['growth']);
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable balance parameters (tick duration, rounding rules, speed/discount bounds) and loader
- inject the balance config into CostService and ResourceTickService to drop hard-coded coefficients
- wire the new services in the container and cover YAML effect handling plus config parsing

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cfccdefce48332a6f8c458e819899d