### PR TITLE
Add balance loader tests and fleet resolution coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": "^8.1",
         "ext-pdo": "*",
+        "symfony/yaml": "^7.3",
         "vlucas/phpdotenv": "^5.5"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "499c50426c090e1422e861052d01ff05",
+    "content-hash": "7d07893cf83543707d94dcb85705167f",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -142,6 +142,73 @@
                 }
             ],
             "time": "2025-08-21T11:53:16+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -394,6 +461,82 @@
                 }
             ],
             "time": "2025-01-02T08:10:11+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -3420,73 +3563,6 @@
                 }
             ],
             "time": "2025-08-25T06:35:40+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/event-dispatcher",

--- a/config/balance/buildings.yaml
+++ b/config/balance/buildings.yaml
@@ -1,0 +1,261 @@
+metal_mine:
+  label: 'Mine de métal'
+  base_cost:
+    metal: 60
+    crystal: 15
+  base_time: 20
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 100
+  prod_growth: 1.15
+  energy_use_base: 10
+  energy_use_growth: 1.1
+  energy_use_linear: true
+  affects: metal
+  image: assets/svg/illustrations/buildings/metal-mine.svg
+  requires:
+    buildings: {  }
+    research: {  }
+crystal_mine:
+  label: 'Mine de cristal'
+  base_cost:
+    metal: 48
+    crystal: 24
+  base_time: 25
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 50
+  prod_growth: 1.15
+  energy_use_base: 15
+  energy_use_growth: 1.1
+  energy_use_linear: true
+  affects: crystal
+  image: assets/svg/illustrations/buildings/crystal-mine.svg
+  requires:
+    buildings: {  }
+    research: {  }
+solar_plant:
+  label: 'Centrale solaire'
+  base_cost:
+    metal: 120
+    crystal: 60
+  base_time: 30
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 100
+  prod_growth: 1.12
+  energy_use_base: 0
+  energy_use_growth: 1.0
+  energy_use_linear: false
+  affects: energy
+  image: assets/svg/illustrations/buildings/solar-plant.svg
+  requires:
+    buildings: {  }
+    research: {  }
+fusion_reactor:
+  label: 'Réacteur à fusion'
+  base_cost:
+    metal: 900
+    crystal: 360
+    hydrogen: 180
+  base_time: 60
+  growth_cost: 1.55
+  growth_time: 1.6
+  prod_base: 320
+  prod_growth: 1.18
+  energy_use_base: 0
+  energy_use_growth: 1.0
+  energy_use_linear: false
+  affects: energy
+  image: assets/svg/illustrations/buildings/fusion-reactor.svg
+  requires:
+    buildings:
+      solar_plant: 5
+      hydrogen_plant: 3
+    research:
+      reactor_advanced: 2
+  upkeep:
+    hydrogen:
+      base: 30
+      growth: 1.16
+antimatter_reactor:
+  label: 'Réacteur à antimatière'
+  base_cost:
+    metal: 3200
+    crystal: 2200
+    hydrogen: 1200
+  base_time: 90
+  growth_cost: 1.55
+  growth_time: 1.6
+  prod_base: 800
+  prod_growth: 1.2
+  energy_use_base: 0
+  energy_use_growth: 1.0
+  energy_use_linear: false
+  affects: energy
+  image: assets/svg/illustrations/buildings/antimatter-reactor.svg
+  requires:
+    buildings:
+      fusion_reactor: 5
+      research_lab: 6
+    research:
+      reactor_antimatter: 1
+  upkeep:
+    hydrogen:
+      base: 60
+      growth: 1.2
+hydrogen_plant:
+  label: 'Générateur d’hydrogène'
+  base_cost:
+    metal: 150
+    crystal: 100
+  base_time: 35
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 30
+  prod_growth: 1.15
+  energy_use_base: 20
+  energy_use_growth: 1.1
+  energy_use_linear: true
+  affects: hydrogen
+  image: assets/svg/illustrations/buildings/hydrogen-plant.svg
+  requires:
+    buildings:
+      solar_plant: 1
+    research: {  }
+storage_depot:
+  label: 'Entrepôt planétaire'
+  base_cost:
+    metal: 1000
+    crystal: 400
+  base_time: 55
+  growth_cost: 1.6
+  growth_time: 1.6
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 0
+  energy_use_growth: 1.0
+  energy_use_linear: false
+  affects: storage
+  image: assets/svg/illustrations/buildings/storage-depot.svg
+  requires:
+    buildings:
+      metal_mine: 4
+      crystal_mine: 3
+    research:
+      logistics: 2
+  storage:
+    metal:
+      base: 50000
+      growth: 1.6
+    crystal:
+      base: 40000
+      growth: 1.6
+    hydrogen:
+      base: 30000
+      growth: 1.6
+    energy:
+      base: 2500
+      growth: 1.5
+worker_factory:
+  label: 'Complexe d’ouvriers'
+  base_cost:
+    metal: 420
+    crystal: 160
+  base_time: 45
+  growth_cost: 1.6
+  growth_time: 1.55
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 18
+  energy_use_growth: 1.12
+  energy_use_linear: true
+  affects: infrastructure
+  image: assets/svg/illustrations/buildings/worker-factory.svg
+  requires:
+    buildings:
+      metal_mine: 4
+      crystal_mine: 3
+    research: {  }
+  construction_speed_bonus:
+    per_level: 0.01
+    max: 0.99
+robot_factory:
+  label: 'Chantier robotique'
+  base_cost:
+    metal: 2400
+    crystal: 1200
+    hydrogen: 300
+  base_time: 85
+  growth_cost: 1.75
+  growth_time: 1.65
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 36
+  energy_use_growth: 1.2
+  energy_use_linear: true
+  affects: infrastructure
+  image: assets/svg/illustrations/buildings/robot-factory.svg
+  requires:
+    buildings:
+      worker_factory: 6
+      research_lab: 2
+    research:
+      engineering_heavy: 3
+  construction_speed_bonus:
+    per_level: 0.03
+    max: 0.99
+  upkeep:
+    hydrogen:
+      base: 12
+      growth: 1.15
+research_lab:
+  label: 'Laboratoire Helios'
+  base_cost:
+    metal: 200
+    crystal: 320
+    hydrogen: 80
+  base_time: 40
+  growth_cost: 1.65
+  growth_time: 1.6
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 22
+  energy_use_growth: 1.22
+  energy_use_linear: true
+  affects: energy
+  image: assets/svg/illustrations/buildings/research-lab.svg
+  requires:
+    buildings:
+      solar_plant: 1
+      crystal_mine: 1
+    research: {  }
+  research_speed_bonus:
+    base: 0.01
+    linear: true
+    max: 0.99
+shipyard:
+  label: 'Chantier spatial Asterion'
+  base_cost:
+    metal: 420
+    crystal: 260
+    hydrogen: 120
+  base_time: 45
+  growth_cost: 1.7
+  growth_time: 1.65
+  prod_base: 0
+  prod_growth: 1.0
+  energy_use_base: 35
+  energy_use_growth: 1.25
+  energy_use_linear: true
+  affects: energy
+  ship_build_speed_bonus:
+    base: 0.01
+    linear: true
+    max: 0.99
+  image: assets/svg/illustrations/buildings/shipyard.svg
+  requires:
+    buildings:
+      research_lab: 1
+    research:
+      engineering_heavy: 1

--- a/config/balance/research.yaml
+++ b/config/balance/research.yaml
@@ -1,0 +1,362 @@
+propulsion_basic:
+  label: 'Propulsion spatiale'
+  category: Propulsion
+  description: 'Maîtrise des moteurs ioniques et de la navigation subluminique.'
+  base_cost:
+    metal: 120
+    crystal: 80
+    hydrogen: 40
+  base_time: 50
+  growth_cost: 1.65
+  growth_time: 1.6
+  max_level: 10
+  requires: {  }
+  requires_lab: 1
+  image: assets/svg/illustrations/research/propulsion.svg
+life_support:
+  label: 'Systèmes de survie'
+  category: Ingénierie
+  description: 'Contrôle environnemental, recyclage et maintien des équipages.'
+  base_cost:
+    metal: 90
+    crystal: 110
+    hydrogen: 40
+  base_time: 55
+  growth_cost: 1.6
+  growth_time: 1.55
+  max_level: 10
+  requires: {  }
+  requires_lab: 1
+  image: assets/svg/illustrations/research/engineering.svg
+miniaturisation:
+  label: 'Miniaturisation des systèmes'
+  category: Ingénierie
+  description: 'Réduction des composants pour optimiser la place à bord.'
+  base_cost:
+    metal: 140
+    crystal: 150
+    hydrogen: 60
+  base_time: 60
+  growth_cost: 1.65
+  growth_time: 1.6
+  max_level: 10
+  requires:
+    life_support: 2
+  requires_lab: 1
+  image: assets/svg/illustrations/research/engineering.svg
+armor_basic:
+  label: 'Blindage de base'
+  category: Défense
+  description: 'Plaques composites et renforts structurels élémentaires.'
+  base_cost:
+    metal: 160
+    crystal: 120
+    hydrogen: 40
+  base_time: 65
+  growth_cost: 1.65
+  growth_time: 1.65
+  max_level: 10
+  requires:
+    miniaturisation: 2
+  requires_lab: 1
+  image: assets/svg/illustrations/research/defense.svg
+weapon_light:
+  label: 'Armes légères'
+  category: Armement
+  description: 'Lasers, canons automatiques et missiles à courte portée.'
+  base_cost:
+    metal: 150
+    crystal: 170
+    hydrogen: 60
+  base_time: 70
+  growth_cost: 1.65
+  growth_time: 1.6
+  max_level: 10
+  requires:
+    miniaturisation: 2
+  requires_lab: 1
+  image: assets/svg/illustrations/research/armament.svg
+radar_basic:
+  label: 'Détection basique'
+  category: Capteurs
+  description: 'Radars tactiques et balayage à courte portée.'
+  base_cost:
+    metal: 110
+    crystal: 160
+    hydrogen: 60
+  base_time: 65
+  growth_cost: 1.6
+  growth_time: 1.55
+  max_level: 10
+  requires:
+    miniaturisation: 1
+  requires_lab: 1
+  image: assets/svg/illustrations/research/sensors.svg
+armor_enhanced:
+  label: 'Blindage renforcé'
+  category: Défense
+  description: 'Alliages avancés et champs de confinement structurels.'
+  base_cost:
+    metal: 260
+    crystal: 210
+    hydrogen: 90
+  base_time: 90
+  growth_cost: 1.7
+  growth_time: 1.65
+  max_level: 10
+  requires:
+    armor_basic: 5
+  requires_lab: 2
+  image: assets/svg/illustrations/research/defense.svg
+shield_energy:
+  label: 'Boucliers énergétiques'
+  category: Défense
+  description: 'Générateurs de champs déflecteurs et boucliers phaseurs.'
+  base_cost:
+    metal: 240
+    crystal: 260
+    hydrogen: 140
+  base_time: 95
+  growth_cost: 1.72
+  growth_time: 1.65
+  max_level: 10
+  requires:
+    armor_enhanced: 3
+    weapon_light: 4
+  requires_lab: 2
+  image: assets/svg/illustrations/research/defense.svg
+weapon_medium:
+  label: 'Armes moyennes'
+  category: Armement
+  description: 'Torpilles lourdes et batteries laser à longue portée.'
+  base_cost:
+    metal: 260
+    crystal: 280
+    hydrogen: 160
+  base_time: 100
+  growth_cost: 1.7
+  growth_time: 1.65
+  max_level: 10
+  requires:
+    weapon_light: 6
+  requires_lab: 2
+  image: assets/svg/illustrations/research/armament.svg
+logistics:
+  label: 'Logistique spatiale'
+  category: Ingénierie
+  description: 'Ravitaillement interplanétaire et coordination des convois.'
+  base_cost:
+    metal: 220
+    crystal: 200
+    hydrogen: 140
+  base_time: 90
+  growth_cost: 1.68
+  growth_time: 1.62
+  max_level: 10
+  requires:
+    propulsion_basic: 4
+    life_support: 4
+  requires_lab: 2
+  image: assets/svg/illustrations/research/engineering.svg
+engineering_heavy:
+  label: 'Ingénierie lourde'
+  category: Ingénierie
+  description: 'Conception de structures massives et docks orbitaux.'
+  base_cost:
+    metal: 320
+    crystal: 260
+    hydrogen: 160
+  base_time: 110
+  growth_cost: 1.72
+  growth_time: 1.68
+  max_level: 10
+  requires:
+    logistics: 3
+  requires_lab: 2
+  image: assets/svg/illustrations/research/engineering.svg
+reactor_advanced:
+  label: 'Réacteurs avancés'
+  category: Propulsion
+  description: 'Réacteurs à fusion haute densité et confinement magnétique.'
+  base_cost:
+    metal: 380
+    crystal: 340
+    hydrogen: 200
+  base_time: 130
+  growth_cost: 1.75
+  growth_time: 1.7
+  max_level: 10
+  requires:
+    propulsion_basic: 5
+    engineering_heavy: 2
+  requires_lab: 3
+  image: assets/svg/illustrations/research/propulsion.svg
+weapon_heavy:
+  label: 'Armes lourdes'
+  category: Armement
+  description: 'Railguns, canons à plasma et plates-formes multi-batteries.'
+  base_cost:
+    metal: 420
+    crystal: 380
+    hydrogen: 260
+  base_time: 140
+  growth_cost: 1.75
+  growth_time: 1.72
+  max_level: 10
+  requires:
+    weapon_medium: 5
+    reactor_advanced: 2
+  requires_lab: 3
+  image: assets/svg/illustrations/research/armament.svg
+tactical_coordination:
+  label: 'Coordination tactique'
+  category: Commandement
+  description: 'IA stratégique et communications quantiques longue portée.'
+  base_cost:
+    metal: 360
+    crystal: 420
+    hydrogen: 200
+  base_time: 135
+  growth_cost: 1.7
+  growth_time: 1.68
+  max_level: 10
+  requires:
+    radar_basic: 5
+    logistics: 5
+  requires_lab: 3
+  image: assets/svg/illustrations/research/command.svg
+superstructures:
+  label: Superstructures
+  category: Ingénierie
+  description: 'Coques modulaires géantes et architecture segmentée.'
+  base_cost:
+    metal: 520
+    crystal: 460
+    hydrogen: 260
+  base_time: 150
+  growth_cost: 1.78
+  growth_time: 1.72
+  max_level: 10
+  requires:
+    engineering_heavy: 5
+  requires_lab: 4
+  image: assets/svg/illustrations/research/engineering.svg
+reactor_antimatter:
+  label: 'Réacteurs à antimatière'
+  category: Propulsion
+  description: 'Confinement annulaire et catalyseurs d’antimatière.'
+  base_cost:
+    metal: 620
+    crystal: 540
+    hydrogen: 340
+  base_time: 170
+  growth_cost: 1.8
+  growth_time: 1.75
+  max_level: 10
+  requires:
+    reactor_advanced: 6
+    superstructures: 3
+  requires_lab: 4
+  image: assets/svg/illustrations/research/propulsion.svg
+weapon_capital:
+  label: 'Armement capital'
+  category: Armement
+  description: 'Super-canons, bombardement orbital et charges de siège.'
+  base_cost:
+    metal: 680
+    crystal: 620
+    hydrogen: 360
+  base_time: 180
+  growth_cost: 1.82
+  growth_time: 1.76
+  max_level: 10
+  requires:
+    weapon_heavy: 6
+    superstructures: 4
+  requires_lab: 4
+  image: assets/svg/illustrations/research/armament.svg
+defense_multilayer:
+  label: 'Défense multi-couches'
+  category: Défense
+  description: 'Combinaison de boucliers adaptatifs et d’armures composites.'
+  base_cost:
+    metal: 640
+    crystal: 560
+    hydrogen: 340
+  base_time: 175
+  growth_cost: 1.78
+  growth_time: 1.74
+  max_level: 10
+  requires:
+    armor_enhanced: 6
+    shield_energy: 5
+  requires_lab: 4
+  image: assets/svg/illustrations/research/defense.svg
+stellar_shipyards:
+  label: 'Chantiers stellaires'
+  category: Construction
+  description: 'Assemblage orbital massif et infrastructures d’amarrage.'
+  base_cost:
+    metal: 720
+    crystal: 660
+    hydrogen: 420
+  base_time: 185
+  growth_cost: 1.8
+  growth_time: 1.76
+  max_level: 10
+  requires:
+    superstructures: 5
+    engineering_heavy: 7
+  requires_lab: 4
+  image: assets/svg/illustrations/research/construction.svg
+autonomous_hangars:
+  label: 'Hangars autonomes'
+  category: Construction
+  description: 'Réseaux de lancement automatisés pour escadrilles de chasseurs.'
+  base_cost:
+    metal: 760
+    crystal: 680
+    hydrogen: 440
+  base_time: 190
+  growth_cost: 1.8
+  growth_time: 1.78
+  max_level: 10
+  requires:
+    stellar_shipyards: 2
+    tactical_coordination: 4
+  requires_lab: 4
+  image: assets/svg/illustrations/research/construction.svg
+super_weapon:
+  label: 'Armes de destruction massive'
+  category: Armement
+  description: 'Rayons planétaires, bombardements orbitaux et super-armes.'
+  base_cost:
+    metal: 880
+    crystal: 760
+    hydrogen: 520
+  base_time: 210
+  growth_cost: 1.85
+  growth_time: 1.8
+  max_level: 10
+  requires:
+    weapon_capital: 4
+    reactor_antimatter: 4
+  requires_lab: 5
+  image: assets/svg/illustrations/research/armament.svg
+fleet_networks:
+  label: 'Réseaux stratégiques de flotte'
+  category: Commandement
+  description: 'Commandement interstellaire et coordination des armadas.'
+  base_cost:
+    metal: 820
+    crystal: 780
+    hydrogen: 480
+  base_time: 205
+  growth_cost: 1.82
+  growth_time: 1.78
+  max_level: 10
+  requires:
+    tactical_coordination: 6
+    autonomous_hangars: 3
+  requires_lab: 5
+  image: assets/svg/illustrations/research/command.svg

--- a/config/balance/ships.yaml
+++ b/config/balance/ships.yaml
@@ -1,0 +1,481 @@
+fighter:
+  label: 'Ailes Lyrae'
+  category: 'Petits vaisseaux'
+  role: 'Chasseur léger de supériorité spatiale'
+  description: 'Véhicule agile conçu pour intercepter rapidement les menaces proches et saturer la défense adverse.'
+  base_cost:
+    metal: 220
+    crystal: 90
+    hydrogen: 45
+  build_time: 60
+  stats:
+    attaque: 6
+    défense: 3
+    vitesse: 18
+  requires_research:
+    propulsion_basic: 1
+    life_support: 2
+    miniaturisation: 2
+    weapon_light: 2
+    radar_basic: 1
+  image: assets/svg/illustrations/ships/light-wing.svg
+bomber:
+  label: 'Maraudeur Obsidien'
+  category: 'Petits vaisseaux'
+  role: 'Bombardier d’assaut lourd'
+  description: 'Transporte un arsenal de torpilles magnétiques capables de briser le blindage des cibles capitales.'
+  base_cost:
+    metal: 420
+    crystal: 260
+    hydrogen: 120
+  build_time: 140
+  stats:
+    attaque: 15
+    défense: 6
+    vitesse: 12
+  requires_research:
+    life_support: 2
+    miniaturisation: 2
+    armor_basic: 2
+    weapon_light: 6
+    weapon_medium: 1
+  image: assets/svg/illustrations/ships/light-wing.svg
+interceptor:
+  label: 'Éclair Stentor'
+  category: 'Petits vaisseaux'
+  role: 'Intercepteur ultrarapide'
+  description: 'Priorité à la vitesse et à la précision pour contrer les chasseurs ennemis et les éclaireurs.'
+  base_cost:
+    metal: 280
+    crystal: 160
+    hydrogen: 90
+  build_time: 90
+  stats:
+    attaque: 7
+    défense: 4
+    vitesse: 24
+  requires_research:
+    propulsion_basic: 2
+    life_support: 3
+    miniaturisation: 3
+    weapon_light: 3
+    radar_basic: 3
+  image: assets/svg/illustrations/ships/light-wing.svg
+heavy_fighter:
+  label: 'Griffon Halcyon'
+  category: 'Petits vaisseaux'
+  role: 'Chasseur lourd polyvalent'
+  description: 'Combine l’armement d’un bombardier à la mobilité d’un intercepteur pour dominer la ligne de front.'
+  base_cost:
+    metal: 520
+    crystal: 360
+    hydrogen: 160
+  build_time: 180
+  stats:
+    attaque: 18
+    défense: 10
+    vitesse: 16
+  requires_research:
+    propulsion_basic: 3
+    life_support: 3
+    miniaturisation: 4
+    weapon_light: 4
+    radar_basic: 3
+    armor_basic: 3
+  image: assets/svg/illustrations/ships/light-wing.svg
+corvette:
+  label: 'Corvette Vigilum'
+  category: 'Unités d’escorte'
+  role: 'Plateforme polyvalente de patrouille'
+  description: 'Assure la reconnaissance, la couverture anti-chasseur et la projection rapide de puissance légère.'
+  base_cost:
+    metal: 950
+    crystal: 520
+    hydrogen: 220
+  build_time: 300
+  stats:
+    attaque: 28
+    défense: 22
+    vitesse: 14
+  requires_research:
+    propulsion_basic: 4
+    life_support: 4
+    logistics: 1
+    armor_basic: 5
+    armor_enhanced: 1
+    weapon_light: 6
+    weapon_medium: 3
+    radar_basic: 3
+  image: assets/svg/illustrations/ships/escort-frigate.svg
+gunship:
+  label: 'Havoc Aster'
+  category: 'Unités d’escorte'
+  role: 'Canonnière à saturation de feu'
+  description: 'Embarque des canons à plasma lourds pour perforer les coques des navires moyens.'
+  base_cost:
+    metal: 1250
+    crystal: 720
+    hydrogen: 260
+  build_time: 420
+  stats:
+    attaque: 40
+    défense: 28
+    vitesse: 12
+  requires_research:
+    armor_basic: 5
+    armor_enhanced: 1
+    weapon_light: 6
+    weapon_medium: 2
+    radar_basic: 3
+  image: assets/svg/illustrations/ships/escort-frigate.svg
+frigate:
+  label: 'Frégate Solstice'
+  category: 'Unités d’escorte'
+  role: 'Frégate anti-chasseur'
+  description: 'Grille de missiles défensifs et batteries traçantes pour protéger les unités capitales.'
+  base_cost:
+    metal: 2200
+    crystal: 1350
+    hydrogen: 480
+  build_time: 600
+  stats:
+    attaque: 55
+    défense: 48
+    vitesse: 10
+  requires_research:
+    armor_basic: 5
+    armor_enhanced: 3
+    weapon_light: 4
+    shield_energy: 1
+    weapon_medium: 4
+    propulsion_basic: 4
+    life_support: 4
+    logistics: 2
+    tactical_coordination: 1
+  image: assets/svg/illustrations/ships/escort-frigate.svg
+destroyer:
+  label: 'Destroyer Fulguris'
+  category: 'Navires de ligne'
+  role: 'Chasseur de frégates et croiseurs'
+  description: 'Longue coque bardée de canons rails optimisés pour démanteler les escorteurs ennemis.'
+  base_cost:
+    metal: 3600
+    crystal: 2400
+    hydrogen: 800
+  build_time: 900
+  stats:
+    attaque: 80
+    défense: 60
+    vitesse: 9
+  requires_research:
+    engineering_heavy: 2
+    propulsion_basic: 5
+    reactor_advanced: 2
+    weapon_light: 6
+    weapon_medium: 5
+    weapon_heavy: 1
+    tactical_coordination: 3
+  image: assets/svg/illustrations/ships/line-cruiser.svg
+light_cruiser:
+  label: 'Croiseur Lumen'
+  category: 'Navires de ligne'
+  role: 'Croiseur léger polyvalent'
+  description: 'Équilibre propulsion, blindage et puissance de feu pour mener des flottes rapides.'
+  base_cost:
+    metal: 5200
+    crystal: 3600
+    hydrogen: 1200
+  build_time: 1200
+  stats:
+    attaque: 110
+    défense: 95
+    vitesse: 8
+  requires_research:
+    engineering_heavy: 3
+    armor_basic: 6
+    armor_enhanced: 3
+    weapon_light: 4
+    shield_energy: 3
+    reactor_advanced: 3
+    weapon_medium: 5
+    weapon_heavy: 2
+    tactical_coordination: 3
+  image: assets/svg/illustrations/ships/line-cruiser.svg
+heavy_cruiser:
+  label: 'Croiseur Axiom'
+  category: 'Navires de ligne'
+  role: 'Croiseur lourd de percée'
+  description: 'Blindage renforcé, artillerie lourde et systèmes de projection pour les batailles d’attrition.'
+  base_cost:
+    metal: 8800
+    crystal: 6200
+    hydrogen: 1800
+  build_time: 1800
+  stats:
+    attaque: 150
+    défense: 140
+    vitesse: 7
+  requires_research:
+    engineering_heavy: 5
+    superstructures: 1
+    reactor_advanced: 4
+    weapon_medium: 5
+    weapon_heavy: 3
+    armor_basic: 6
+    armor_enhanced: 6
+    weapon_light: 5
+    shield_energy: 5
+    defense_multilayer: 2
+    tactical_coordination: 4
+  image: assets/svg/illustrations/ships/line-cruiser.svg
+battleship:
+  label: 'Cuirassé Helior'
+  category: 'Navires lourds'
+  role: 'Cuirassé de ligne'
+  description: 'Boucliers étagés et batteries orbitales massives pour absorber et infliger d’énormes dégâts.'
+  base_cost:
+    metal: 15000
+    crystal: 9800
+    hydrogen: 2600
+  build_time: 2700
+  stats:
+    attaque: 220
+    défense: 260
+    vitesse: 6
+  requires_research:
+    engineering_heavy: 5
+    superstructures: 4
+    reactor_advanced: 6
+    reactor_antimatter: 1
+    weapon_medium: 6
+    weapon_heavy: 6
+    weapon_capital: 1
+    armor_basic: 6
+    armor_enhanced: 6
+    weapon_light: 5
+    shield_energy: 5
+    defense_multilayer: 3
+  image: assets/svg/illustrations/ships/heavy-battleship.svg
+battlecruiser:
+  label: 'Arbiter Solaris'
+  category: 'Navires lourds'
+  role: 'Croiseur de bataille'
+  description: 'Compromis entre vitesse et artillerie lourde pour manœuvrer autour des cuirassés ennemis.'
+  base_cost:
+    metal: 18800
+    crystal: 12600
+    hydrogen: 3200
+  build_time: 3300
+  stats:
+    attaque: 240
+    défense: 210
+    vitesse: 7
+  requires_research:
+    engineering_heavy: 5
+    superstructures: 2
+    reactor_advanced: 5
+    weapon_medium: 5
+    weapon_heavy: 4
+    tactical_coordination: 5
+  image: assets/svg/illustrations/ships/heavy-battleship.svg
+dreadnought:
+  label: 'Dreadnought Orichal'
+  category: 'Navires lourds'
+  role: 'Dreadnought d’assaut'
+  description: 'Pièce maîtresse d’une armada, concentrant le feu de multiples batteries super-lourdes.'
+  base_cost:
+    metal: 26000
+    crystal: 18000
+    hydrogen: 4200
+  build_time: 4200
+  stats:
+    attaque: 320
+    défense: 320
+    vitesse: 5
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 4
+    reactor_advanced: 6
+    reactor_antimatter: 2
+    weapon_heavy: 6
+    weapon_capital: 2
+    armor_enhanced: 6
+    shield_energy: 5
+    defense_multilayer: 4
+    tactical_coordination: 6
+    stellar_shipyards: 2
+  image: assets/svg/illustrations/ships/heavy-battleship.svg
+carrier:
+  label: 'Porte-chasseurs Aegira'
+  category: 'Capitaux spécialisés'
+  role: 'Transport et projection de chasseurs'
+  description: 'Hangars magnétiques pouvant lancer simultanément des vagues complètes d’escadrilles.'
+  base_cost:
+    metal: 22000
+    crystal: 21000
+    hydrogen: 5200
+  build_time: 4500
+  stats:
+    attaque: 180
+    défense: 300
+    vitesse: 5
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 5
+    stellar_shipyards: 2
+    tactical_coordination: 4
+    autonomous_hangars: 3
+    reactor_advanced: 5
+    weapon_medium: 5
+    shield_energy: 5
+    armor_enhanced: 6
+    fleet_networks: 2
+  image: assets/svg/illustrations/ships/capital-carrier.svg
+heavy_transport:
+  label: 'Transporteur Atlas'
+  category: 'Capitaux spécialisés'
+  role: 'Transport lourd interplanétaire'
+  description: 'Plate-forme d’atterrissage blindée pour déployer troupes, véhicules ou modules orbitaux.'
+  base_cost:
+    metal: 12800
+    crystal: 9000
+    hydrogen: 6400
+  build_time: 3000
+  stats:
+    attaque: 70
+    défense: 150
+    vitesse: 6
+  requires_research:
+    propulsion_basic: 4
+    life_support: 4
+    logistics: 3
+    engineering_heavy: 2
+    armor_basic: 3
+    weapon_light: 3
+    tactical_coordination: 1
+  image: assets/svg/illustrations/ships/capital-carrier.svg
+command_ship:
+  label: 'Vaisseau de commandement Novarch'
+  category: 'Capitaux spécialisés'
+  role: 'Centre de commandement stratégique'
+  description: 'Coordinateur de flotte doté de suites tactiques avancées et de systèmes de communications quantiques.'
+  base_cost:
+    metal: 24000
+    crystal: 20000
+    hydrogen: 7000
+  build_time: 4800
+  stats:
+    attaque: 160
+    défense: 340
+    vitesse: 5
+  requires_research:
+    tactical_coordination: 5
+    fleet_networks: 2
+    autonomous_hangars: 2
+    shield_energy: 4
+    armor_enhanced: 4
+    weapon_medium: 4
+  image: assets/svg/illustrations/ships/capital-carrier.svg
+super_battleship:
+  label: 'Super-cuirassé Empyrium'
+  category: 'Vaisseaux colossaux'
+  role: 'Super-cuirassé de domination'
+  description: 'Vaisseau emblématique, quasiment indestructible, arborant une armure multi-couches et un armement d’anéantissement.'
+  base_cost:
+    metal: 54000
+    crystal: 42000
+    hydrogen: 12000
+  build_time: 9000
+  stats:
+    attaque: 420
+    défense: 520
+    vitesse: 4
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 5
+    stellar_shipyards: 3
+    reactor_advanced: 6
+    reactor_antimatter: 3
+    weapon_heavy: 6
+    weapon_capital: 3
+    armor_enhanced: 6
+    shield_energy: 5
+    defense_multilayer: 5
+  image: assets/svg/illustrations/ships/colossus.svg
+siege_breaker:
+  label: 'Cuirassé de siège Ragnarok'
+  category: 'Vaisseaux colossaux'
+  role: 'Bélier orbital'
+  description: 'Optimisé pour raser les fortifications planétaires grâce à des canons gravitoniques massifs.'
+  base_cost:
+    metal: 62000
+    crystal: 46000
+    hydrogen: 15000
+  build_time: 9600
+  stats:
+    attaque: 480
+    défense: 480
+    vitesse: 4
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 5
+    stellar_shipyards: 3
+    weapon_capital: 3
+    super_weapon: 1
+    reactor_antimatter: 3
+    defense_multilayer: 4
+    shield_energy: 5
+  image: assets/svg/illustrations/ships/colossus.svg
+super_dreadnought:
+  label: 'Super-dreadnought Nemesis'
+  category: 'Vaisseaux colossaux'
+  role: 'Arme capitale ultime'
+  description: 'Capable de déployer un canon stellaire, ce navire dicte l’issue de n’importe quelle bataille.'
+  base_cost:
+    metal: 72000
+    crystal: 56000
+    hydrogen: 18000
+  build_time: 10800
+  stats:
+    attaque: 560
+    défense: 580
+    vitesse: 3
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 5
+    stellar_shipyards: 3
+    reactor_advanced: 6
+    reactor_antimatter: 4
+    weapon_heavy: 6
+    weapon_capital: 4
+    super_weapon: 1
+    armor_enhanced: 6
+    shield_energy: 5
+    defense_multilayer: 5
+    fleet_networks: 3
+  image: assets/svg/illustrations/ships/colossus.svg
+battle_station:
+  label: 'Citadelle Astra'
+  category: 'Stations stellaires'
+  role: 'Station spatiale armée'
+  description: 'Forteresse orbitale dotée d’un anneau de super-lasers et de plates-formes autonomes.'
+  base_cost:
+    metal: 95000
+    crystal: 82000
+    hydrogen: 25000
+  build_time: 14400
+  stats:
+    attaque: 680
+    défense: 760
+    vitesse: 0
+  requires_research:
+    engineering_heavy: 7
+    superstructures: 6
+    stellar_shipyards: 4
+    armor_enhanced: 6
+    shield_energy: 5
+    defense_multilayer: 5
+    weapon_capital: 3
+    super_weapon: 1
+    fleet_networks: 3
+  image: assets/svg/illustrations/ships/battle-station.svg

--- a/src/Domain/Service/FleetResolutionService.php
+++ b/src/Domain/Service/FleetResolutionService.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace App\Domain\Service;
+
+use InvalidArgumentException;
+
+class FleetResolutionService
+{
+    /**
+     * @param array<string, int> $attacker
+     * @param array<string, int> $defender
+     * @param array<string, array<string, mixed>> $shipDefinitions
+     *
+     * @return array{
+     *     outcome: 'attacker'|'defender'|'stalemate',
+     *     attacker_remaining: array<string, int>,
+     *     defender_remaining: array<string, int>,
+     *     attacker_losses: array<string, int>,
+     *     defender_losses: array<string, int>,
+     *     rounds: array<int, array{
+     *         attacker: array{attack: int, defense: int, losses: array<string, int>, remaining: array<string, int>},
+     *         defender: array{attack: int, defense: int, losses: array<string, int>, remaining: array<string, int>},
+     *     }>
+     * }
+     */
+    public function resolveBattle(array $attacker, array $defender, array $shipDefinitions, int $maxRounds = 6): array
+    {
+        if ($maxRounds <= 0) {
+            throw new InvalidArgumentException('Max rounds must be greater than zero.');
+        }
+
+        $attackerFleet = $this->normalizeFleet($attacker);
+        $defenderFleet = $this->normalizeFleet($defender);
+
+        $rounds = [];
+        $attackerLosses = $this->emptyFleet(array_keys($attackerFleet));
+        $defenderLosses = $this->emptyFleet(array_keys($defenderFleet));
+        $allShipKeys = array_unique(array_merge(array_keys($attackerFleet), array_keys($defenderFleet)));
+
+        foreach (array_diff($allShipKeys, array_keys($attackerLosses)) as $key) {
+            $attackerLosses[$key] = 0;
+        }
+        foreach (array_diff($allShipKeys, array_keys($defenderLosses)) as $key) {
+            $defenderLosses[$key] = 0;
+        }
+
+        for ($round = 1; $round <= $maxRounds; $round++) {
+            if ($this->isFleetDestroyed($attackerFleet) || $this->isFleetDestroyed($defenderFleet)) {
+                break;
+            }
+
+            $attackerAttack = $this->totalAttack($attackerFleet, $shipDefinitions);
+            $defenderAttack = $this->totalAttack($defenderFleet, $shipDefinitions);
+            $attackerDefense = $this->totalDefense($attackerFleet, $shipDefinitions);
+            $defenderDefense = $this->totalDefense($defenderFleet, $shipDefinitions);
+
+            $attackerCasualties = $this->calculateCasualties($defenderAttack, $attackerDefense, $attackerFleet, $shipDefinitions);
+            $defenderCasualties = $this->calculateCasualties($attackerAttack, $defenderDefense, $defenderFleet, $shipDefinitions);
+
+            $rounds[$round] = [
+                'attacker' => [
+                    'attack' => $attackerAttack,
+                    'defense' => $attackerDefense,
+                    'losses' => $attackerCasualties,
+                    'remaining' => $attackerFleet,
+                ],
+                'defender' => [
+                    'attack' => $defenderAttack,
+                    'defense' => $defenderDefense,
+                    'losses' => $defenderCasualties,
+                    'remaining' => $defenderFleet,
+                ],
+            ];
+
+            $attackerLosses = $this->sumLosses($attackerLosses, $attackerCasualties);
+            $defenderLosses = $this->sumLosses($defenderLosses, $defenderCasualties);
+
+            $attackerFleet = $this->applyCasualties($attackerFleet, $attackerCasualties);
+            $defenderFleet = $this->applyCasualties($defenderFleet, $defenderCasualties);
+        }
+
+        $outcome = $this->determineOutcome($attackerFleet, $defenderFleet);
+
+        ksort($attackerFleet);
+        ksort($defenderFleet);
+        ksort($attackerLosses);
+        ksort($defenderLosses);
+
+        return [
+            'outcome' => $outcome,
+            'attacker_remaining' => $attackerFleet,
+            'defender_remaining' => $defenderFleet,
+            'attacker_losses' => $attackerLosses,
+            'defender_losses' => $defenderLosses,
+            'rounds' => $rounds,
+        ];
+    }
+
+    /**
+     * @param array<string, int> $fleet
+     *
+     * @return array<string, int>
+     */
+    private function normalizeFleet(array $fleet): array
+    {
+        $normalized = [];
+
+        foreach ($fleet as $key => $quantity) {
+            $quantity = (int) $quantity;
+            if ($quantity <= 0) {
+                continue;
+            }
+
+            $normalized[$key] = $quantity;
+        }
+
+        ksort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @param string[] $keys
+     *
+     * @return array<string, int>
+     */
+    private function emptyFleet(array $keys): array
+    {
+        $empty = [];
+        foreach ($keys as $key) {
+            $empty[$key] = 0;
+        }
+
+        return $empty;
+    }
+
+    /**
+     * @param array<string, int> $fleet
+     * @param array<string, array<string, mixed>> $shipDefinitions
+     */
+    private function totalAttack(array $fleet, array $shipDefinitions): int
+    {
+        $total = 0.0;
+        foreach ($fleet as $key => $quantity) {
+            $attack = $this->statForShip($shipDefinitions, $key, 'attaque');
+            $total += $quantity * $attack;
+        }
+
+        return (int) round($total);
+    }
+
+    /**
+     * @param array<string, int> $fleet
+     * @param array<string, array<string, mixed>> $shipDefinitions
+     */
+    private function totalDefense(array $fleet, array $shipDefinitions): int
+    {
+        $total = 0.0;
+        foreach ($fleet as $key => $quantity) {
+            $defense = $this->statForShip($shipDefinitions, $key, 'défense');
+            $total += $quantity * $defense;
+        }
+
+        return (int) round($total);
+    }
+
+    /**
+     * @param array<string, int> $fleet
+     * @param array<string, int> $casualties
+     *
+     * @return array<string, int>
+     */
+    private function applyCasualties(array $fleet, array $casualties): array
+    {
+        foreach ($casualties as $key => $loss) {
+            if (!isset($fleet[$key])) {
+                continue;
+            }
+
+            $fleet[$key] = max(0, $fleet[$key] - $loss);
+            if ($fleet[$key] === 0) {
+                unset($fleet[$key]);
+            }
+        }
+
+        ksort($fleet);
+
+        return $fleet;
+    }
+
+    /**
+     * @param array<string, int> $existing
+     * @param array<string, int> $additional
+     *
+     * @return array<string, int>
+     */
+    private function sumLosses(array $existing, array $additional): array
+    {
+        foreach ($additional as $key => $value) {
+            if (!isset($existing[$key])) {
+                $existing[$key] = 0;
+            }
+
+            $existing[$key] += $value;
+        }
+
+        return $existing;
+    }
+
+    /**
+     * @param array<string, int> $fleet
+     */
+    private function isFleetDestroyed(array $fleet): bool
+    {
+        foreach ($fleet as $quantity) {
+            if ($quantity > 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, int> $fleet
+     * @param array<string, array<string, mixed>> $shipDefinitions
+     *
+     * @return array<string, int>
+     */
+    private function calculateCasualties(int $incomingAttack, int $targetDefense, array $fleet, array $shipDefinitions): array
+    {
+        if ($incomingAttack <= 0 || $this->isFleetDestroyed($fleet)) {
+            return $this->emptyFleet(array_keys($fleet));
+        }
+
+        if ($targetDefense <= 0) {
+            return $fleet;
+        }
+
+        $casualties = [];
+        $remainingDamage = (float) $incomingAttack;
+        $defenseTotal = (float) max(1, $targetDefense);
+
+        foreach ($fleet as $key => $quantity) {
+            $shipDefense = max(1.0, $this->statForShip($shipDefinitions, $key, 'défense'));
+            $shipDefenseTotal = $quantity * $shipDefense;
+
+            if ($shipDefenseTotal <= 0) {
+                $casualties[$key] = $quantity;
+                continue;
+            }
+
+            $proportion = $shipDefenseTotal / $defenseTotal;
+            $damageForShip = $incomingAttack * $proportion;
+            $destroyed = (int) floor($damageForShip / $shipDefense);
+
+            if ($destroyed > $quantity) {
+                $destroyed = $quantity;
+            }
+
+            // ensure we do not lose damage share completely when small amounts accumulate
+            if ($destroyed < $quantity) {
+                $remainingDamage -= $destroyed * $shipDefense;
+            } else {
+                $remainingDamage -= $quantity * $shipDefense;
+            }
+
+            if ($destroyed < $quantity && $remainingDamage > 0 && $damageForShip > 0 && ($damageForShip / $shipDefense) > $destroyed) {
+                $destroyed = min($quantity, $destroyed + 1);
+                $remainingDamage -= $shipDefense;
+            }
+
+            $casualties[$key] = max(0, $destroyed);
+        }
+
+        return $casualties;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $shipDefinitions
+     */
+    private function statForShip(array $shipDefinitions, string $key, string $stat): float
+    {
+        $definition = $shipDefinitions[$key] ?? null;
+        if (!is_array($definition) || empty($definition['stats']) || !is_array($definition['stats'])) {
+            return 0.0;
+        }
+
+        $stats = $definition['stats'];
+        if (!isset($stats[$stat])) {
+            return 0.0;
+        }
+
+        return (float) $stats[$stat];
+    }
+
+    /**
+     * @param array<string, int> $attackerRemaining
+     * @param array<string, int> $defenderRemaining
+     *
+     * @return 'attacker'|'defender'|'stalemate'
+     */
+    private function determineOutcome(array $attackerRemaining, array $defenderRemaining): string
+    {
+        $attackerDestroyed = $this->isFleetDestroyed($attackerRemaining);
+        $defenderDestroyed = $this->isFleetDestroyed($defenderRemaining);
+
+        if ($attackerDestroyed && $defenderDestroyed) {
+            return 'stalemate';
+        }
+
+        if ($defenderDestroyed) {
+            return 'attacker';
+        }
+
+        if ($attackerDestroyed) {
+            return 'defender';
+        }
+
+        return 'stalemate';
+    }
+}

--- a/src/Infrastructure/Config/BalanceConfigLoader.php
+++ b/src/Infrastructure/Config/BalanceConfigLoader.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Infrastructure\Config;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+final class BalanceConfigLoader
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $files;
+
+    /**
+     * @param array<string, string> $files
+     */
+    public function __construct(
+        private readonly string $basePath,
+        array $files = [
+            'buildings' => 'buildings.yaml',
+            'research' => 'research.yaml',
+            'ships' => 'ships.yaml',
+        ]
+    ) {
+        if (!is_dir($basePath)) {
+            throw new InvalidArgumentException(sprintf('Balance configuration directory "%s" does not exist.', $basePath));
+        }
+
+        $this->files = $files;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function loadBuildings(): array
+    {
+        /** @var array<string, array<string, mixed>> $config */
+        $config = $this->load('buildings');
+
+        return $config;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function loadResearch(): array
+    {
+        /** @var array<string, array<string, mixed>> $config */
+        $config = $this->load('research');
+
+        return $config;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function loadShips(): array
+    {
+        /** @var array<string, array<string, mixed>> $config */
+        $config = $this->load('ships');
+
+        return $config;
+    }
+
+    /**
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    public function loadAll(): array
+    {
+        $result = [];
+
+        foreach (array_keys($this->files) as $section) {
+            $result[$section] = $this->load($section);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function load(string $section): array
+    {
+        $file = $this->files[$section] ?? null;
+        if ($file === null) {
+            throw new InvalidArgumentException(sprintf('Unknown balance configuration section "%s".', $section));
+        }
+
+        $path = rtrim($this->basePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $file;
+        if (!is_file($path)) {
+            throw new RuntimeException(sprintf('Balance configuration file "%s" was not found.', $path));
+        }
+
+        try {
+            $parsed = Yaml::parseFile($path, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE | Yaml::PARSE_CONSTANT);
+        } catch (ParseException $exception) {
+            throw new RuntimeException(sprintf('Unable to parse balance configuration file "%s".', $path), 0, $exception);
+        }
+
+        if ($parsed === null) {
+            return [];
+        }
+
+        if (!is_array($parsed)) {
+            throw new RuntimeException(sprintf('Balance configuration file "%s" must define an array structure.', $path));
+        }
+
+        return $this->normalize($parsed);
+    }
+
+    /**
+     * @param array<string|int, mixed> $data
+     *
+     * @return array<string|int, mixed>
+     */
+    private function normalize(array $data): array
+    {
+        $normalized = [];
+
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $normalized[$key] = $this->normalize($value);
+
+                continue;
+            }
+
+            if (is_int($value) || is_float($value) || is_string($value) || is_bool($value) || $value === null) {
+                $normalized[$key] = $value;
+
+                continue;
+            }
+
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
+    }
+}

--- a/tests/Unit/CostServiceTest.php
+++ b/tests/Unit/CostServiceTest.php
@@ -5,37 +5,58 @@ declare(strict_types=1);
 namespace App\Tests\Unit;
 
 use App\Domain\Service\CostService;
+use App\Infrastructure\Config\BalanceConfigLoader;
 use PHPUnit\Framework\TestCase;
 
 class CostServiceTest extends TestCase
 {
     private CostService $service;
 
+    private BalanceConfigLoader $loader;
+
     protected function setUp(): void
     {
         $this->service = new CostService();
+        $basePath = dirname(__DIR__, 2) . '/config/balance';
+        $this->loader = new BalanceConfigLoader($basePath);
     }
 
-    public function testNextLevelAndCumulativeCost(): void
+    public function testMetalMineNextLevelCostMatchesLegacyValues(): void
     {
-        $baseCost = ['metal' => 100, 'crystal' => 50];
+        $buildings = $this->loader->loadBuildings();
+        $metalMine = $buildings['metal_mine'];
 
-        $level0Cost = $this->service->nextLevelCost($baseCost, 1.5, 0);
-        $level2Cost = $this->service->nextLevelCost($baseCost, 1.5, 2);
+        $level5Cost = $this->service->nextLevelCost($metalMine['base_cost'], (float) $metalMine['growth_cost'], 5);
+        $level9Cost = $this->service->nextLevelCost($metalMine['base_cost'], (float) $metalMine['growth_cost'], 9);
 
-        self::assertSame(['metal' => 100, 'crystal' => 50], $level0Cost);
-        self::assertSame(['metal' => 225, 'crystal' => 113], $level2Cost);
-
-        $cumulative = $this->service->cumulativeCost($baseCost, 1.5, 0, 3);
-        self::assertSame(['metal' => 100 + 150 + 225, 'crystal' => 50 + 75 + 113], $cumulative);
+        self::assertSame(['metal' => 629, 'crystal' => 157], $level5Cost);
+        self::assertSame(['metal' => 4123, 'crystal' => 1031], $level9Cost);
     }
 
-    public function testScaledDurationAndDiscount(): void
+    public function testPropulsionResearchCumulativeCostFromSnapshots(): void
     {
-        $duration = $this->service->scaledDuration(60, 1.6, 2, 2.0);
-        self::assertSame(77, $duration);
+        $research = $this->loader->loadResearch();
+        $tech = $research['propulsion_basic'];
 
-        $discounted = $this->service->applyDiscount(['metal' => 1000, 'crystal' => 400], 0.2);
-        self::assertSame(['metal' => 800, 'crystal' => 320], $discounted);
+        $cumulative = $this->service->cumulativeCost($tech['base_cost'], (float) $tech['growth_cost'], 0, 3);
+
+        self::assertSame([
+            'metal' => 645,
+            'crystal' => 430,
+            'hydrogen' => 215,
+        ], $cumulative);
+    }
+
+    public function testScaledDurationAndDiscountMatchReferenceCalculations(): void
+    {
+        $buildings = $this->loader->loadBuildings();
+        $researchLab = $buildings['research_lab'];
+        $shipyard = $buildings['shipyard'];
+
+        $duration = $this->service->scaledDuration((int) $researchLab['base_time'], (float) $researchLab['growth_time'], 5, 1.35);
+        self::assertSame(311, $duration);
+
+        $discounted = $this->service->applyDiscount($shipyard['base_cost'], 0.15);
+        self::assertSame(['metal' => 357, 'crystal' => 221, 'hydrogen' => 102], $discounted);
     }
 }

--- a/tests/Unit/FleetResolutionServiceTest.php
+++ b/tests/Unit/FleetResolutionServiceTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit;
+
+use App\Domain\Service\FleetResolutionService;
+use App\Infrastructure\Config\BalanceConfigLoader;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class FleetResolutionServiceTest extends TestCase
+{
+    private FleetResolutionService $service;
+
+    /** @var array<string, array<string, mixed>> */
+    private array $ships;
+
+    protected function setUp(): void
+    {
+        $loader = new BalanceConfigLoader(dirname(__DIR__, 2) . '/config/balance');
+        $this->ships = $loader->loadShips();
+        $this->service = new FleetResolutionService();
+    }
+
+    public function testAttackerOverwhelmsDefendersSnapshot(): void
+    {
+        $result = $this->service->resolveBattle(
+            ['battlecruiser' => 4, 'heavy_cruiser' => 3, 'destroyer' => 6],
+            ['fighter' => 40, 'frigate' => 10, 'battleship' => 2],
+            $this->ships,
+            6
+        );
+
+        self::assertSame('attacker', $result['outcome']);
+        self::assertSame(['destroyer' => 1, 'heavy_cruiser' => 1], $result['attacker_remaining']);
+        self::assertSame([], $result['defender_remaining']);
+        self::assertSame([
+            'battlecruiser' => 4,
+            'battleship' => 0,
+            'destroyer' => 5,
+            'fighter' => 0,
+            'frigate' => 0,
+            'heavy_cruiser' => 2,
+        ], $result['attacker_losses']);
+        self::assertSame([
+            'battlecruiser' => 0,
+            'battleship' => 2,
+            'destroyer' => 0,
+            'fighter' => 40,
+            'frigate' => 10,
+            'heavy_cruiser' => 0,
+        ], $result['defender_losses']);
+
+        $firstRound = $result['rounds'][1];
+        self::assertSame(1890, $firstRound['attacker']['attack']);
+        self::assertSame(1620, $firstRound['attacker']['defense']);
+        self::assertSame([
+            'battlecruiser' => 4,
+            'destroyer' => 5,
+            'heavy_cruiser' => 2,
+        ], $firstRound['attacker']['losses']);
+        self::assertSame(1230, $firstRound['defender']['attack']);
+        self::assertSame(1120, $firstRound['defender']['defense']);
+        self::assertSame([
+            'battleship' => 2,
+            'fighter' => 40,
+            'frigate' => 10,
+        ], $firstRound['defender']['losses']);
+    }
+
+    public function testDefenderHoldsLineAgainstSmallerForce(): void
+    {
+        $result = $this->service->resolveBattle(
+            ['fighter' => 5, 'bomber' => 2],
+            ['destroyer' => 4, 'heavy_cruiser' => 2],
+            $this->ships,
+            6
+        );
+
+        self::assertSame('defender', $result['outcome']);
+        self::assertSame([], $result['attacker_remaining']);
+        self::assertSame([
+            'destroyer' => 3,
+            'heavy_cruiser' => 2,
+        ], $result['defender_remaining']);
+        self::assertSame([
+            'bomber' => 2,
+            'destroyer' => 0,
+            'fighter' => 5,
+            'heavy_cruiser' => 0,
+        ], $result['attacker_losses']);
+        self::assertSame([
+            'bomber' => 0,
+            'destroyer' => 1,
+            'fighter' => 0,
+            'heavy_cruiser' => 0,
+        ], $result['defender_losses']);
+
+        $firstRound = $result['rounds'][1];
+        self::assertSame(60, $firstRound['attacker']['attack']);
+        self::assertSame(27, $firstRound['attacker']['defense']);
+        self::assertSame(620, $firstRound['defender']['attack']);
+        self::assertSame(520, $firstRound['defender']['defense']);
+    }
+
+    public function testMutualDestructionYieldsStalemateSnapshot(): void
+    {
+        $result = $this->service->resolveBattle(
+            ['fighter' => 20, 'bomber' => 8, 'destroyer' => 3],
+            ['fighter' => 15, 'frigate' => 4, 'light_cruiser' => 2],
+            $this->ships,
+            6
+        );
+
+        self::assertSame('stalemate', $result['outcome']);
+        self::assertSame([], $result['attacker_remaining']);
+        self::assertSame([], $result['defender_remaining']);
+        self::assertSame([
+            'bomber' => 8,
+            'destroyer' => 3,
+            'fighter' => 20,
+            'frigate' => 0,
+            'light_cruiser' => 0,
+        ], $result['attacker_losses']);
+        self::assertSame([
+            'bomber' => 0,
+            'destroyer' => 0,
+            'fighter' => 15,
+            'frigate' => 4,
+            'light_cruiser' => 2,
+        ], $result['defender_losses']);
+
+        $firstRound = $result['rounds'][1];
+        self::assertSame(480, $firstRound['attacker']['attack']);
+        self::assertSame(288, $firstRound['attacker']['defense']);
+        self::assertSame(530, $firstRound['defender']['attack']);
+        self::assertSame(427, $firstRound['defender']['defense']);
+    }
+
+    public function testResolveBattleRejectsInvalidRoundLimit(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->service->resolveBattle([], [], $this->ships, 0);
+    }
+}

--- a/tests/Unit/Infrastructure/Config/BalanceConfigLoaderTest.php
+++ b/tests/Unit/Infrastructure/Config/BalanceConfigLoaderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure\Config;
+
+use App\Infrastructure\Config\BalanceConfigLoader;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class BalanceConfigLoaderTest extends TestCase
+{
+    private string $configPath;
+
+    protected function setUp(): void
+    {
+        $this->configPath = dirname(__DIR__, 4) . '/config/balance';
+    }
+
+    public function testLoadsBuildingsConfigIdenticalToLegacyPhpArrays(): void
+    {
+        $loader = new BalanceConfigLoader($this->configPath);
+
+        $expected = require dirname(__DIR__, 4) . '/config/game/buildings.php';
+        $actual = $loader->loadBuildings();
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testLoadsResearchConfigIdenticalToLegacyPhpArrays(): void
+    {
+        $loader = new BalanceConfigLoader($this->configPath);
+
+        $expected = require dirname(__DIR__, 4) . '/config/game/research.php';
+        $actual = $loader->loadResearch();
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testLoadsShipConfigIdenticalToLegacyPhpArrays(): void
+    {
+        $loader = new BalanceConfigLoader($this->configPath);
+
+        $expected = require dirname(__DIR__, 4) . '/config/game/ships.php';
+        $actual = $loader->loadShips();
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testLoadAllReturnsCompleteDataset(): void
+    {
+        $loader = new BalanceConfigLoader($this->configPath);
+
+        $all = $loader->loadAll();
+
+        self::assertCount(3, $all);
+        self::assertSame($loader->loadBuildings(), $all['buildings']);
+        self::assertSame($loader->loadResearch(), $all['research']);
+        self::assertSame($loader->loadShips(), $all['ships']);
+    }
+
+    public function testThrowsWhenSectionUnknown(): void
+    {
+        $loader = new BalanceConfigLoader($this->configPath);
+
+        $this->expectException(InvalidArgumentException::class);
+        $loader->load('unknown');
+    }
+
+    public function testThrowsWhenFileMissing(): void
+    {
+        $loader = new BalanceConfigLoader($this->configPath, ['buildings' => 'missing.yaml']);
+
+        $this->expectException(RuntimeException::class);
+        $loader->load('buildings');
+    }
+
+    public function testThrowsWhenBasePathInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new BalanceConfigLoader('/does/not/exist');
+    }
+}

--- a/tests/Unit/ResourceTickServiceTest.php
+++ b/tests/Unit/ResourceTickServiceTest.php
@@ -4,72 +4,33 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit;
 
+use App\Domain\Service\ResourceEffectFactory;
 use App\Domain\Service\ResourceTickService;
+use App\Infrastructure\Config\BalanceConfigLoader;
 use DateInterval;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 class ResourceTickServiceTest extends TestCase
 {
+    private ResourceTickService $service;
+
+    protected function setUp(): void
+    {
+        $basePath = dirname(__DIR__, 2) . '/config/balance';
+        $loader = new BalanceConfigLoader($basePath);
+        $effects = ResourceEffectFactory::fromBuildingConfig($loader->loadBuildings());
+
+        $this->service = new ResourceTickService($effects);
+    }
+
     public function testTickUpdatesResourcesForMultiplePlanets(): void
     {
-        $service = new ResourceTickService();
-
-        $effects = [
-            'metal_mine' => [
-                'produces' => [
-                    'metal' => ['base' => 30, 'growth' => 1.15],
-                ],
-                'energy' => [
-                    'consumption' => ['base' => 10, 'growth' => 1.08, 'linear' => true],
-                ],
-            ],
-            'crystal_mine' => [
-                'produces' => [
-                    'crystal' => ['base' => 20, 'growth' => 1.14],
-                ],
-                'energy' => [
-                    'consumption' => ['base' => 12, 'growth' => 1.08, 'linear' => true],
-                ],
-            ],
-            'solar_plant' => [
-                'energy' => [
-                    'production' => ['base' => 40, 'growth' => 1.13],
-                ],
-            ],
-            'fusion_reactor' => [
-                'energy' => [
-                    'production' => ['base' => 320, 'growth' => 1.18],
-                ],
-                'consumes' => [
-                    'hydrogen' => ['base' => 30, 'growth' => 1.16],
-                ],
-            ],
-            'antimatter_reactor' => [
-                'energy' => [
-                    'production' => ['base' => 800, 'growth' => 1.2],
-                ],
-                'consumes' => [
-                    'hydrogen' => ['base' => 60, 'growth' => 1.2],
-                ],
-            ],
-            'storage_depot' => [
-                'storage' => [
-                    'metal' => ['base' => 5000, 'growth' => 1.5],
-                    'crystal' => ['base' => 4000, 'growth' => 1.4],
-                    'hydrogen' => ['base' => 3000, 'growth' => 1.4],
-                    'energy' => ['base' => 25, 'growth' => 1.2],
-                ],
-            ],
-        ];
-
         $lastTick = new DateTimeImmutable('2025-09-20 10:00:00');
         $now = $lastTick->add(new DateInterval('PT2H'));
 
         $planetStates = [
             1 => [
-                'planet_id' => 1,
-                'player_id' => 10,
                 'resources' => [
                     'metal' => 1000,
                     'crystal' => 500,
@@ -99,8 +60,6 @@ class ResourceTickServiceTest extends TestCase
                 ],
             ],
             2 => [
-                'planet_id' => 2,
-                'player_id' => 20,
                 'resources' => [
                     'metal' => 5000,
                     'crystal' => 2500,
@@ -128,191 +87,147 @@ class ResourceTickServiceTest extends TestCase
             ],
         ];
 
-        $result = $service->tick($planetStates, $now, $effects);
+        $result = $this->service->tick($planetStates, $now);
 
         self::assertCount(2, $result);
         $planetOne = $result[1];
+        self::assertSame([
+            'metal' => 1349,
+            'crystal' => 632,
+            'hydrogen' => 10,
+            'energy' => 2380,
+        ], $planetOne['resources']);
+        self::assertSame([
+            'metal' => 175,
+            'crystal' => 66,
+            'hydrogen' => -95,
+            'energy' => 1190,
+        ], $planetOne['production_per_hour']);
+        self::assertSame([
+            'metal' => 90000,
+            'crystal' => 72000,
+            'hydrogen' => 53000,
+            'energy' => 3850,
+        ], $planetOne['capacities']);
+        self::assertSame([
+            'production' => 1318,
+            'consumption' => 128,
+            'balance' => 1190,
+            'available' => 2380,
+            'ratio' => 1.0,
+        ], $planetOne['energy']);
+        self::assertSame(7200, $planetOne['elapsed_seconds']);
+
         $planetTwo = $result[2];
-
-        $rawMetalPerHour = 30 * pow(1.15, 4);
-        $rawCrystalPerHour = 20 * pow(1.14, 2);
-        $energyProduction = (40 * pow(1.13, 3)) + (320 * pow(1.18, 1)) + (800 * pow(1.2, 0));
-        $energyConsumption = (10 * pow(1.08, 4) * 5) + (12 * pow(1.08, 2) * 3);
-        $energyRatio = max(0.0, min(1.0, $energyProduction / $energyConsumption));
-        $expectedMetalPerHour = $rawMetalPerHour * $energyRatio;
-        $expectedCrystalPerHour = $rawCrystalPerHour * $energyRatio;
-        $hydrogenConsumptionPerHour = (30 * pow(1.16, 1) + 60 * pow(1.2, 0)) * $energyRatio;
-
-        $expectedMetalAfter = (int) floor(1000 + $expectedMetalPerHour * 2 + 0.000001);
-        $expectedCrystalAfter = (int) floor(500 + $expectedCrystalPerHour * 2 + 0.000001);
-        $expectedHydrogenAfter = (int) floor(200 - $hydrogenConsumptionPerHour * 2 + 0.000001);
-
-        self::assertEqualsWithDelta($expectedMetalAfter, $planetOne['resources']['metal'], 1.0);
-        self::assertEqualsWithDelta($expectedCrystalAfter, $planetOne['resources']['crystal'], 1.0);
-        self::assertEqualsWithDelta($expectedHydrogenAfter, $planetOne['resources']['hydrogen'], 1.0);
-        self::assertEqualsWithDelta($energyProduction, $planetOne['energy']['production'], 0.5);
-        self::assertSame(17500, $planetOne['capacities']['metal']);
-        self::assertSame(130, $planetOne['capacities']['energy']);
-        self::assertSame(130, $planetOne['resources']['energy']);
-        self::assertSame(2 * 3600, $planetOne['elapsed_seconds']);
-        self::assertEqualsWithDelta($energyRatio, $planetOne['energy']['ratio'], 0.0001);
-        self::assertSame(130, $planetOne['energy']['available']);
-
-        self::assertSame($planetStates[2]['resources']['metal'], $planetTwo['resources']['metal']);
-        self::assertSame($planetStates[2]['resources']['crystal'], $planetTwo['resources']['crystal']);
-        self::assertGreaterThan($planetStates[2]['capacities']['metal'], $planetTwo['capacities']['metal']);
-        self::assertSame(0, $planetTwo['energy']['production']);
-        self::assertSame(0, $planetTwo['energy']['available']);
+        self::assertSame([
+            'metal' => 5000,
+            'crystal' => 2500,
+            'hydrogen' => 1500,
+            'energy' => 0,
+        ], $planetTwo['resources']);
+        self::assertSame([
+            'metal' => 0,
+            'crystal' => 0,
+            'energy' => -69,
+        ], $planetTwo['production_per_hour']);
+        self::assertSame([
+            'metal' => 58000,
+            'crystal' => 46000,
+            'hydrogen' => 34000,
+            'energy' => 2550,
+        ], $planetTwo['capacities']);
+        self::assertSame([
+            'production' => 0,
+            'consumption' => 69,
+            'balance' => -69,
+            'available' => 0,
+            'ratio' => 0.0,
+        ], $planetTwo['energy']);
+        self::assertSame(7200, $planetTwo['elapsed_seconds']);
     }
 
     public function testStorageCapacityRemainsStableAcrossSequentialTicks(): void
     {
-        $effects = [
-            'storage_depot' => [
-                'storage' => [
-                    'metal' => ['base' => 5000, 'growth' => 1.5],
-                    'crystal' => ['base' => 2500, 'growth' => 1.4],
-                    'hydrogen' => ['base' => 2000, 'growth' => 1.3],
-                    'energy' => ['base' => 50, 'growth' => 1.1],
-                ],
-            ],
-        ];
-
-        $service = new ResourceTickService($effects);
-
         $startTick = new DateTimeImmutable('2025-09-20 08:00:00');
         $firstTickTime = $startTick->add(new DateInterval('PT1H'));
 
         $initialState = [
-            'planet_id' => 1,
-            'player_id' => 10,
-            'resources' => [
-                'metal' => 2000,
-                'crystal' => 1000,
-                'hydrogen' => 500,
-                'energy' => 0,
-            ],
-            'capacities' => [
-                'metal' => 10000,
-                'crystal' => 8000,
-                'hydrogen' => 6000,
-                'energy' => 100,
-            ],
-            'base_capacities' => [
-                'metal' => 10000,
-                'crystal' => 8000,
-                'hydrogen' => 6000,
-                'energy' => 100,
-            ],
+            'resources' => ['metal' => 2000, 'crystal' => 1000, 'hydrogen' => 500, 'energy' => 0],
+            'capacities' => ['metal' => 10000, 'crystal' => 8000, 'hydrogen' => 6000, 'energy' => 100],
+            'base_capacities' => ['metal' => 10000, 'crystal' => 8000, 'hydrogen' => 6000, 'energy' => 100],
             'last_tick' => $startTick,
-            'building_levels' => [
-                'storage_depot' => 2,
-            ],
+            'building_levels' => ['storage_depot' => 2],
         ];
 
-        $firstTickResult = $service->tick([1 => $initialState], $firstTickTime);
-        $firstPlanetTick = $firstTickResult[1];
+        $firstTick = $this->service->tick([1 => $initialState], $firstTickTime)[1];
 
-        self::assertSame(17500, $firstPlanetTick['capacities']['metal']);
+        self::assertSame([
+            'metal' => 90000,
+            'crystal' => 72000,
+            'hydrogen' => 54000,
+            'energy' => 3850,
+        ], $firstTick['capacities']);
 
         $secondState = $initialState;
+        $secondState['resources'] = $firstTick['resources'];
+        $secondState['capacities'] = $firstTick['capacities'];
         $secondState['last_tick'] = $firstTickTime;
-        $secondState['resources'] = $firstPlanetTick['resources'];
-        $secondState['capacities'] = $firstPlanetTick['capacities'];
 
         $secondTickTime = $firstTickTime->add(new DateInterval('PT1H'));
-        $secondTickResult = $service->tick([1 => $secondState], $secondTickTime);
-        $secondPlanetTick = $secondTickResult[1];
+        $secondTick = $this->service->tick([1 => $secondState], $secondTickTime)[1];
 
-        self::assertSame($firstPlanetTick['capacities']['metal'], $secondPlanetTick['capacities']['metal']);
-        self::assertSame($firstPlanetTick['capacities']['crystal'], $secondPlanetTick['capacities']['crystal']);
-        self::assertSame($firstPlanetTick['capacities']['hydrogen'], $secondPlanetTick['capacities']['hydrogen']);
-        self::assertSame($firstPlanetTick['capacities']['energy'], $secondPlanetTick['capacities']['energy']);
+        self::assertSame($firstTick['capacities'], $secondTick['capacities']);
     }
 
     public function testStorageCapacityDoesNotAccumulateWithoutExplicitBase(): void
     {
-        $effects = [
-            'storage_depot' => [
-                'storage' => [
-                    'metal' => ['base' => 5000, 'growth' => 1.5],
-                    'crystal' => ['base' => 2500, 'growth' => 1.4],
-                    'hydrogen' => ['base' => 2000, 'growth' => 1.3],
-                    'energy' => ['base' => 50, 'growth' => 1.1],
-                ],
-            ],
-        ];
-
-        $service = new ResourceTickService($effects);
-
         $startTick = new DateTimeImmutable('2025-09-20 08:00:00');
         $firstTickTime = $startTick->add(new DateInterval('PT1H'));
 
         $initialCapacities = [
-            'metal' => 17500,
-            'crystal' => 11500,
-            'hydrogen' => 8600,
-            'energy' => 155,
+            'metal' => 90000,
+            'crystal' => 72000,
+            'hydrogen' => 54000,
+            'energy' => 3850,
         ];
 
         $initialState = [
-            'planet_id' => 1,
-            'player_id' => 10,
-            'resources' => [
-                'metal' => 2000,
-                'crystal' => 1000,
-                'hydrogen' => 500,
-                'energy' => 0,
-            ],
+            'resources' => ['metal' => 2000, 'crystal' => 1000, 'hydrogen' => 500, 'energy' => 0],
             'capacities' => $initialCapacities,
             'last_tick' => $startTick,
-            'building_levels' => [
-                'storage_depot' => 2,
-            ],
-            'previous_building_levels' => [
-                'storage_depot' => 2,
-            ],
+            'building_levels' => ['storage_depot' => 2],
+            'previous_building_levels' => ['storage_depot' => 2],
         ];
 
-        $firstTick = $service->tick([1 => $initialState], $firstTickTime);
-        $firstPlanetTick = $firstTick[1];
+        $firstTick = $this->service->tick([1 => $initialState], $firstTickTime)[1];
 
-        self::assertSame($initialCapacities['metal'], $firstPlanetTick['capacities']['metal']);
-        self::assertSame($initialCapacities['crystal'], $firstPlanetTick['capacities']['crystal']);
-        self::assertSame($initialCapacities['hydrogen'], $firstPlanetTick['capacities']['hydrogen']);
-        self::assertSame($initialCapacities['energy'], $firstPlanetTick['capacities']['energy']);
+        self::assertSame($initialCapacities, $firstTick['capacities']);
 
         $secondState = $initialState;
+        $secondState['resources'] = $firstTick['resources'];
+        $secondState['capacities'] = $firstTick['capacities'];
         $secondState['last_tick'] = $firstTickTime;
-        $secondState['resources'] = $firstPlanetTick['resources'];
-        $secondState['capacities'] = $firstPlanetTick['capacities'];
-        $secondState['previous_building_levels'] = $initialState['building_levels'];
 
         $secondTickTime = $firstTickTime->add(new DateInterval('PT1H'));
-        $secondTick = $service->tick([1 => $secondState], $secondTickTime);
-        $secondPlanetTick = $secondTick[1];
+        $secondTick = $this->service->tick([1 => $secondState], $secondTickTime)[1];
 
-        self::assertSame($firstPlanetTick['capacities']['metal'], $secondPlanetTick['capacities']['metal']);
-        self::assertSame($firstPlanetTick['capacities']['crystal'], $secondPlanetTick['capacities']['crystal']);
-        self::assertSame($firstPlanetTick['capacities']['hydrogen'], $secondPlanetTick['capacities']['hydrogen']);
-        self::assertSame($firstPlanetTick['capacities']['energy'], $secondPlanetTick['capacities']['energy']);
+        self::assertSame($firstTick['capacities'], $secondTick['capacities']);
 
         $upgradeState = $secondState;
+        $upgradeState['resources'] = $secondTick['resources'];
+        $upgradeState['capacities'] = $secondTick['capacities'];
         $upgradeState['last_tick'] = $secondTickTime;
-        $upgradeState['resources'] = $secondPlanetTick['resources'];
-        $upgradeState['capacities'] = $secondPlanetTick['capacities'];
         $upgradeState['previous_building_levels'] = $secondState['building_levels'];
-        $upgradeState['building_levels'] = [
-            'storage_depot' => 3,
-        ];
+        $upgradeState['building_levels'] = ['storage_depot' => 3];
 
         $upgradeTickTime = $secondTickTime->add(new DateInterval('PT1H'));
-        $upgradeTick = $service->tick([1 => $upgradeState], $upgradeTickTime);
-        $upgradePlanetTick = $upgradeTick[1];
+        $upgradeTick = $this->service->tick([1 => $upgradeState], $upgradeTickTime)[1];
 
-        self::assertSame(21250, $upgradePlanetTick['capacities']['metal']);
-        self::assertSame(12900, $upgradePlanetTick['capacities']['crystal']);
-        self::assertSame(9380, $upgradePlanetTick['capacities']['hydrogen']);
-        self::assertSame(161, $upgradePlanetTick['capacities']['energy']);
+        self::assertSame([
+            'metal' => 138000,
+            'crystal' => 110400,
+            'hydrogen' => 82800,
+            'energy' => 5725,
+        ], $upgradeTick['capacities']);
     }
 }


### PR DESCRIPTION
## Summary
- add Symfony YAML dependency and export balance data to config/balance/*.yaml
- implement BalanceConfigLoader with unit tests ensuring YAML matches legacy PHP config values
- update cost and resource tick service tests to consume loader snapshots from the new balance data
- add FleetResolutionService with comprehensive battle resolution tests covering attacker wins, defender wins, and stalemates

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cfcce4040883328c09be250ee4bebe