### PR TITLE
Fix controller dependency wiring

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -332,8 +332,6 @@ return function (Container $container): void {
         $c->get(GetBuildingsOverview::class),
         $c->get(UpgradeBuilding::class),
         $c->get(ProcessBuildQueue::class),
-        $c->get(BuildingCatalog::class),
-        $c->get(BuildingCalculator::class),
         $c->get(ViewRenderer::class),
         $c->get(SessionInterface::class),
         $c->get(FlashBag::class),
@@ -342,9 +340,9 @@ return function (Container $container): void {
     ));
 
     $container->set(ResearchController::class, fn (Container $c) => new ResearchController(
+        $c->get(PlanetRepositoryInterface::class),
         $c->get(GetResearchOverview::class),
         $c->get(StartResearch::class),
-        $c->get(GetTechTree::class),
         $c->get(ProcessResearchQueue::class),
         $c->get(ViewRenderer::class),
         $c->get(SessionInterface::class),
@@ -354,6 +352,7 @@ return function (Container $container): void {
     ));
 
     $container->set(ShipyardController::class, fn (Container $c) => new ShipyardController(
+        $c->get(PlanetRepositoryInterface::class),
         $c->get(GetShipyardOverview::class),
         $c->get(BuildShips::class),
         $c->get(ProcessShipBuildQueue::class),


### PR DESCRIPTION
## Summary
- align the ColonyController service definition with its constructor signature by removing the unused building catalog dependencies
- inject the planet repository first for ResearchController and ShipyardController and ensure only the expected collaborators are passed

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cfdfd01c9883328b1fa1a77d178960