### PR TITLE
Fix ResourceApiController service dependencies

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -408,8 +408,16 @@ return function (Container $container): void {
 
     $container->set(ResourceApiController::class, fn (Container $c) => new ResourceApiController(
         $c->get(PlanetRepositoryInterface::class),
+        $c->get(ProcessBuildQueue::class),
+        $c->get(ProcessResearchQueue::class),
+        $c->get(ProcessShipBuildQueue::class),
+        $c->get(BuildingStateRepositoryInterface::class),
         $c->get(ResourceTickService::class),
-        $c->get(SessionInterface::class)
+        $c->get(ViewRenderer::class),
+        $c->get(SessionInterface::class),
+        $c->get(FlashBag::class),
+        $c->get(CsrfTokenManager::class),
+        $c->getParameter('app.base_url')
     ));
 
     $container->set(TechTreeController::class, fn (Container $c) => new TechTreeController(


### PR DESCRIPTION
## Summary
- inject the full set of dependencies required by ResourceApiController via the service container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfec9d85a48332936f65a4eb66437a