### PR TITLE
Refine resource meter layout

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -386,7 +386,6 @@ main.workspace__content {
 .topbar__planet {
     display: flex;
     flex-direction: column;
-    gap: var(--space-1);
 }
 
 .topbar__selector select {
@@ -457,7 +456,6 @@ main.workspace__content {
 .resource-meter__details {
     display: flex;
     flex-direction: column;
-    gap: var(--space-1);
 }
 
 .resource-meter__label {
@@ -465,6 +463,7 @@ main.workspace__content {
     color: var(--color-muted);
     text-transform: uppercase;
     letter-spacing: 0.12em;
+    margin-bottom: var(--space-1);
 }
 
 .resource-meter__values {
@@ -478,7 +477,10 @@ main.workspace__content {
     font-size: 1.25rem;
 }
 
-.resource-meter__capacity {
+.resource-meter__capacity,
+.resource-meter__hint {
+    display: block;
+    margin-top: var(--space-1);
     font-size: var(--font-size-sm);
     color: var(--color-muted);
 }
@@ -503,7 +505,8 @@ main.workspace__content {
 
 .resource-meter--warning .resource-meter__label,
 .resource-meter--warning .resource-meter__value,
-.resource-meter--warning .resource-meter__capacity {
+.resource-meter--warning .resource-meter__capacity,
+.resource-meter--warning .resource-meter__hint {
     color: var(--danger);
 }
 

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -399,8 +399,8 @@ const renderResourceMeter = (key, value, perHour, capacity) => {
 
     if (capacityElement) {
         capacityElement.textContent = normalizedCapacity > 0
-            ? `/ ${formatNumber(normalizedCapacity)}`
-            : '/ —';
+            ? `/${formatNumber(normalizedCapacity)}`
+            : '/—';
     }
 
     meter.dataset.resourceCapacity = String(normalizedCapacity);

--- a/templates/components/_resource_bar.php
+++ b/templates/components/_resource_bar.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/helpers.php';
 
 /**
- * @param array<string, array{label: string, value: int|float, perHour?: int|float, hint?: string, trend?: string}> $resources
+ * @param array<string, array{label: string, value: int|float, perHour?: int|float, capacity?: int|float|null, hint?: string, trend?: string}> $resources
  * @param array{baseUrl?: string, class?: string, showRates?: bool} $options
  */
 return static function (array $resources, array $options = []): string {
@@ -25,6 +25,7 @@ return static function (array $resources, array $options = []): string {
         $label = $data['label'] ?? ucfirst((string) $key);
         $value = (float) ($data['value'] ?? 0);
         $perHour = $data['perHour'] ?? null;
+        $capacity = $data['capacity'] ?? null;
         $hint = $data['hint'] ?? null;
         $trend = $data['trend'] ?? null;
 
@@ -48,6 +49,13 @@ return static function (array $resources, array $options = []): string {
             htmlspecialchars($iconHref, ENT_QUOTES)
         );
 
+        $capacityMarkup = '';
+        if ($capacity !== null) {
+            $numericCapacity = is_numeric($capacity) ? (float) $capacity : 0.0;
+            $capacityDisplay = $numericCapacity > 0 ? '/' . format_number($numericCapacity) : '/—';
+            $capacityMarkup = sprintf('<span class="resource-meter__capacity">%s</span>', htmlspecialchars($capacityDisplay, ENT_QUOTES));
+        }
+
         $hintMarkup = '';
         if ($hint) {
             $hintMarkup = sprintf('<span class="resource-meter__hint">%s</span>', htmlspecialchars((string) $hint, ENT_QUOTES));
@@ -66,6 +74,7 @@ return static function (array $resources, array $options = []): string {
         $items .= '<span class="resource-meter__value">' . htmlspecialchars($valueDisplay, ENT_QUOTES) . '</span>';
         $items .= $rateMarkup;
         $items .= '</div>';
+        $items .= $capacityMarkup;
         $items .= $hintMarkup;
         $items .= '</div>';
         $items .= '</div>';

--- a/templates/layouts/base.php
+++ b/templates/layouts/base.php
@@ -178,7 +178,7 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                         $ratePrefix = ($key !== 'energy' && $perHourValue > 0) ? '+' : '';
                         $rateDisplay = $ratePrefix . $rateNumber . '/h';
                         $rateClass = $perHourValue >= 0 ? 'is-positive' : 'is-negative';
-                        $capacityDisplay = $capacityValue > 0 ? format_number($capacityValue) : '—';
+                        $capacityDisplay = $capacityValue > 0 ? '/' . format_number($capacityValue) : '/—';
                         $meterClasses = 'resource-meter' . (($value <= 0 && $perHourValue < 0) ? ' resource-meter--warning' : '');
                         ?>
                         <div class="<?= $meterClasses ?>" role="group" aria-label="<?= htmlspecialchars($label) ?>" data-resource="<?= htmlspecialchars($key) ?>" data-resource-capacity="<?= $capacityValue ?>">
@@ -191,9 +191,9 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                                 <span class="resource-meter__label"><?= htmlspecialchars($label) ?></span>
                                 <div class="resource-meter__values">
                                     <span class="resource-meter__value" data-resource-value><?= format_number($value) ?></span>
-                                    <span class="resource-meter__capacity" data-resource-capacity-display>/ <?= htmlspecialchars($capacityDisplay) ?></span>
                                     <span class="resource-meter__rate <?= $rateClass ?>" data-resource-rate><?= htmlspecialchars($rateDisplay) ?></span>
                                 </div>
+                                <span class="resource-meter__capacity" data-resource-capacity-display><?= htmlspecialchars($capacityDisplay) ?></span>
                             </div>
                         </div>
                     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- separate resource capacity onto its own line in the top bar and remove the extra space before the slash
- align the shared resource bar component and styles with the new meter structure, including optional capacity and hints
- keep the JS ticker in sync by rendering compact capacity strings without reintroducing the space

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff02d56d08332854adea97af9b33b