### PR TITLE
Align resource meter layout

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -469,9 +469,17 @@ main.workspace__content {
 
 .resource-meter__values {
     display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-1);
+    font-weight: 600;
+}
+
+.resource-meter__primary {
+    display: flex;
     align-items: baseline;
     gap: var(--space-2);
-    font-weight: 600;
+    flex-wrap: wrap;
 }
 
 .resource-meter__value {
@@ -479,13 +487,16 @@ main.workspace__content {
 }
 
 .resource-meter__capacity {
+    display: block;
     font-size: var(--font-size-sm);
     color: var(--color-muted);
+    font-weight: 500;
 }
 
 .resource-meter__rate {
     font-size: var(--font-size-sm);
     color: var(--color-muted);
+    font-weight: 500;
 }
 
 .resource-meter__rate.is-positive {

--- a/templates/components/_resource_bar.php
+++ b/templates/components/_resource_bar.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/helpers.php';
 
 /**
- * @param array<string, array{label: string, value: int|float, perHour?: int|float, hint?: string, trend?: string}> $resources
+ * @param array<string, array{label: string, value: int|float, perHour?: int|float, capacity?: int|float, hint?: string, trend?: string}> $resources
  * @param array{baseUrl?: string, class?: string, showRates?: bool} $options
  */
 return static function (array $resources, array $options = []): string {
@@ -25,6 +25,7 @@ return static function (array $resources, array $options = []): string {
         $label = $data['label'] ?? ucfirst((string) $key);
         $value = (float) ($data['value'] ?? 0);
         $perHour = $data['perHour'] ?? null;
+        $capacity = $data['capacity'] ?? null;
         $hint = $data['hint'] ?? null;
         $trend = $data['trend'] ?? null;
 
@@ -58,13 +59,23 @@ return static function (array $resources, array $options = []): string {
             $rateMarkup = sprintf('<span class="resource-meter__rate %s">%s</span>', htmlspecialchars($rateClass, ENT_QUOTES), htmlspecialchars($rateDisplay, ENT_QUOTES));
         }
 
+        $capacityMarkup = '';
+        if (array_key_exists('capacity', $data)) {
+            $capacityValue = $capacity !== null ? (float) $capacity : 0.0;
+            $formattedCapacity = $capacityValue > 0 ? format_number($capacityValue) : '—';
+            $capacityMarkup = sprintf('<span class="resource-meter__capacity">/ %s</span>', htmlspecialchars($formattedCapacity, ENT_QUOTES));
+        }
+
         $items .= '<div class="resource-meter" role="group" aria-label="' . htmlspecialchars((string) $label, ENT_QUOTES) . '">';
         $items .= '<div class="resource-meter__icon">' . $icon . '</div>';
         $items .= '<div class="resource-meter__details">';
         $items .= '<span class="resource-meter__label">' . htmlspecialchars((string) $label, ENT_QUOTES) . '</span>';
         $items .= '<div class="resource-meter__values">';
+        $items .= '<div class="resource-meter__primary">';
         $items .= '<span class="resource-meter__value">' . htmlspecialchars($valueDisplay, ENT_QUOTES) . '</span>';
         $items .= $rateMarkup;
+        $items .= '</div>';
+        $items .= $capacityMarkup;
         $items .= '</div>';
         $items .= $hintMarkup;
         $items .= '</div>';

--- a/templates/layouts/base.php
+++ b/templates/layouts/base.php
@@ -190,9 +190,11 @@ $currentSectionPath = $menuLookup[$activeSection]['path'] ?? '/dashboard';
                             <div class="resource-meter__details">
                                 <span class="resource-meter__label"><?= htmlspecialchars($label) ?></span>
                                 <div class="resource-meter__values">
-                                    <span class="resource-meter__value" data-resource-value><?= format_number($value) ?></span>
+                                    <div class="resource-meter__primary">
+                                        <span class="resource-meter__value" data-resource-value><?= format_number($value) ?></span>
+                                        <span class="resource-meter__rate <?= $rateClass ?>" data-resource-rate><?= htmlspecialchars($rateDisplay) ?></span>
+                                    </div>
                                     <span class="resource-meter__capacity" data-resource-capacity-display>/ <?= htmlspecialchars($capacityDisplay) ?></span>
-                                    <span class="resource-meter__rate <?= $rateClass ?>" data-resource-rate><?= htmlspecialchars($rateDisplay) ?></span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- pair resource value and hourly rate in a dedicated row and move capacity beneath in the top bar markup
- update the reusable resource bar component to emit the same structure and support optional capacity values
- adjust resource meter styles so the primary row stays horizontal while the capacity text always sits on its own line

## Testing
- npm run lint:css
- php -l templates/layouts/base.php
- php -l templates/components/_resource_bar.php

------
https://chatgpt.com/codex/tasks/task_e_68cff425f61c8332beeb1595cd42baf5