### PR TITLE
Expose base build and research durations

### DIFF
--- a/public/assets/js/__tests__/card-updates.test.js
+++ b/public/assets/js/__tests__/card-updates.test.js
@@ -68,6 +68,7 @@ test('updateBuildingCard refreshes level, costs and requirements', () => {
         canUpgrade: false,
         cost: { metal: 150, crystal: 75 },
         time: 120,
+        baseTime: 180,
         production: { resource: 'metal', current: 30, next: 40 },
         consumption: { energy: { current: 5, next: 7 } },
         storage: { current: {}, next: {}, delta: {} },
@@ -89,6 +90,7 @@ test('updateBuildingCard refreshes level, costs and requirements', () => {
     assert.ok(costList?.textContent?.includes('150'));
     assert.ok(costList?.textContent?.includes('75'));
     assert.ok(costList?.textContent?.includes('2 min'));
+    assert.ok(costList?.innerHTML?.includes('(base 3 min)'));
 
     const requirements = card?.querySelector('.building-card__requirements');
     assert.ok(requirements);
@@ -140,6 +142,7 @@ test('updateResearchCard syncs progress, costs and availability', () => {
         progress: 0.4,
         nextCost: { metal: 100, crystal: 50 },
         nextTime: 180,
+        nextBaseTime: 240,
         requirements: { ok: true, missing: [] },
         canResearch: true,
     });
@@ -161,6 +164,7 @@ test('updateResearchCard syncs progress, costs and availability', () => {
     assert.ok(costList?.textContent?.includes('100'));
     assert.ok(costList?.textContent?.includes('50'));
     assert.ok(costList?.textContent?.includes('3 min'));
+    assert.ok(costList?.innerHTML?.includes('(base 4 min)'));
 
     const requirements = card?.querySelector('.tech-card__requirements');
     assert.equal(requirements, null);
@@ -176,6 +180,7 @@ test('updateResearchCard syncs progress, costs and availability', () => {
         progress: 0.4,
         nextCost: { metal: 100, crystal: 50 },
         nextTime: 180,
+        nextBaseTime: 240,
         requirements: {
             ok: false,
             missing: [

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -105,7 +105,7 @@ const metricValueClass = (value) => {
     return 'metric-line__value metric-line__value--neutral';
 };
 
-const renderCostList = (cost = {}, time = 0) => {
+const renderCostList = (cost = {}, time = 0, baseTime = null) => {
     const items = [];
 
     if (cost && typeof cost === 'object') {
@@ -116,8 +116,23 @@ const renderCostList = (cost = {}, time = 0) => {
         });
     }
 
+    const numericTime = Number(time ?? 0);
+    const normalizedTime = Number.isFinite(numericTime) ? Math.max(0, Math.floor(numericTime)) : 0;
+    let normalizedBaseTime = normalizedTime;
+    if (baseTime !== null && baseTime !== undefined) {
+        const numericBaseTime = Number(baseTime);
+        if (Number.isFinite(numericBaseTime)) {
+            normalizedBaseTime = Math.max(0, Math.floor(numericBaseTime));
+        }
+    }
+
+    const timeLabel = escapeHtml(formatSeconds(normalizedTime));
+    const baseLabel = normalizedBaseTime !== normalizedTime
+        ? ` <small>(base ${escapeHtml(formatSeconds(normalizedBaseTime))})</small>`
+        : '';
+
     items.push(`
-        <li>${createIcon('time')}<span>${escapeHtml(formatSeconds(time))}</span></li>
+        <li>${createIcon('time')}<span>${timeLabel}${baseLabel}</span></li>
     `);
 
     return `<ul class="resource-list">${items.join('')}</ul>`;
@@ -269,7 +284,7 @@ const renderBuildingSections = (building = {}) => {
     const costHtml = `
         <div class="building-card__block">
             <h3>Prochaine amélioration</h3>
-            ${renderCostList(building.cost ?? {}, building.time ?? 0)}
+            ${renderCostList(building.cost ?? {}, building.time ?? 0, building.baseTime ?? null)}
         </div>
     `;
 
@@ -713,7 +728,11 @@ const updateResearchCard = (research) => {
 
     const costSection = card.querySelector('.tech-card__section');
     if (costSection) {
-        costSection.innerHTML = `<h3>Prochaine amélioration</h3>${renderCostList(research.nextCost ?? {}, research.nextTime ?? 0)}`;
+        costSection.innerHTML = `<h3>Prochaine amélioration</h3>${renderCostList(
+            research.nextCost ?? {},
+            research.nextTime ?? 0,
+            research.nextBaseTime ?? null,
+        )}`;
     }
 
     const requirementsHtml = renderResearchRequirements(research.requirements ?? null);

--- a/src/Application/UseCase/Building/GetBuildingsOverview.php
+++ b/src/Application/UseCase/Building/GetBuildingsOverview.php
@@ -138,6 +138,7 @@ class GetBuildingsOverview
             $effectiveLevel = $projectedLevels[$definition->getKey()] ?? $currentLevel;
             $nextTargetLevel = $effectiveLevel + 1;
             $cost = $this->calculator->nextCost($definition, $effectiveLevel);
+            $baseTime = $this->calculator->nextTime($definition, $effectiveLevel);
             $time = $this->calculator->nextTime($definition, $effectiveLevel, $projectedLevels);
             $requirements = $this->calculator->checkRequirements($definition, $levels, $researchLevels, $researchCatalogMap);
             if (!empty($requirements['missing'])) {
@@ -225,6 +226,7 @@ class GetBuildingsOverview
                 'level' => $currentLevel,
                 'cost' => $cost,
                 'time' => $time,
+                'baseTime' => $baseTime,
                 'requirements' => $requirements,
                 'canUpgrade' => $canUpgrade,
                 'production' => [

--- a/src/Application/UseCase/Research/GetResearchOverview.php
+++ b/src/Application/UseCase/Research/GetResearchOverview.php
@@ -84,6 +84,7 @@ class GetResearchOverview
                 $effectiveResearchLevels = $researchLevels;
                 $effectiveResearchLevels[$definition->getKey()] = $effectiveLevel;
                 $nextCost = $this->calculator->nextCost($definition, $effectiveLevel);
+                $nextBaseTime = $this->calculator->nextTime($definition, $effectiveLevel, 0);
                 $nextTime = $this->calculator->nextTime($definition, $effectiveLevel, $labLevel);
                 $requirements = $this->calculator->checkRequirements(
                     $definition,
@@ -106,6 +107,7 @@ class GetResearchOverview
                     'progress' => $definition->getMaxLevel() > 0 ? min(1.0, $currentLevel / $definition->getMaxLevel()) : 0,
                     'nextCost' => $nextCost,
                     'nextTime' => $nextTime,
+                    'nextBaseTime' => $nextBaseTime,
                     'requirements' => $requirements,
                     'canResearch' => $canResearch,
                 ];

--- a/src/Controller/ColonyController.php
+++ b/src/Controller/ColonyController.php
@@ -250,6 +250,7 @@ class ColonyController extends AbstractController
             'canUpgrade' => (bool) ($entry['canUpgrade'] ?? false),
             'cost' => array_map(static fn ($value) => (int) $value, $entry['cost'] ?? []),
             'time' => (int) ($entry['time'] ?? 0),
+            'baseTime' => (int) ($entry['baseTime'] ?? 0),
             'production' => [
                 'resource' => (string) ($production['resource'] ?? ''),
                 'current' => (int) ($production['current'] ?? 0),

--- a/src/Controller/ResearchController.php
+++ b/src/Controller/ResearchController.php
@@ -243,6 +243,7 @@ class ResearchController extends AbstractController
             'progress' => (float) ($entry['progress'] ?? 0.0),
             'nextCost' => array_map(static fn ($value) => (int) $value, $entry['nextCost'] ?? []),
             'nextTime' => (int) ($entry['nextTime'] ?? 0),
+            'nextBaseTime' => (int) ($entry['nextBaseTime'] ?? 0),
             'requirements' => [
                 'ok' => (bool) ($requirements['ok'] ?? false),
                 'missing' => $missing,

--- a/templates/pages/colony/index.php
+++ b/templates/pages/colony/index.php
@@ -185,7 +185,13 @@ ob_start();
                                 echo '<span>' . format_number((int) $amount) . '</span>';
                                 echo '</li>';
                             }
-                            echo '<li>' . $icon('time', ['baseUrl' => $baseUrl, 'class' => 'icon-sm']) . '<span>' . htmlspecialchars(format_duration((int) $building['time'])) . '</span></li>';
+                            $buildTime = (int) ($building['time'] ?? 0);
+                            $baseBuildTime = (int) ($building['baseTime'] ?? $buildTime);
+                            echo '<li>' . $icon('time', ['baseUrl' => $baseUrl, 'class' => 'icon-sm']) . '<span>' . htmlspecialchars(format_duration($buildTime));
+                            if ($baseBuildTime !== $buildTime) {
+                                echo ' <small>(base ' . htmlspecialchars(format_duration($baseBuildTime)) . ')</small>';
+                            }
+                            echo '</span></li>';
                             echo '</ul>';
                             echo '</div>';
 

--- a/templates/pages/research/index.php
+++ b/templates/pages/research/index.php
@@ -127,7 +127,13 @@ ob_start();
                             foreach ($item['nextCost'] as $resource => $amount) {
                                 echo '<li>' . $icon((string) $resource, ['baseUrl' => $baseUrl, 'class' => 'icon-sm']) . '<span>' . format_number((int) $amount) . '</span></li>';
                             }
-                            echo '<li>' . $icon('time', ['baseUrl' => $baseUrl, 'class' => 'icon-sm']) . '<span>' . htmlspecialchars(format_duration((int) $item['nextTime'])) . '</span></li>';
+                            $nextTime = (int) ($item['nextTime'] ?? 0);
+                            $nextBaseTime = (int) ($item['nextBaseTime'] ?? $nextTime);
+                            echo '<li>' . $icon('time', ['baseUrl' => $baseUrl, 'class' => 'icon-sm']) . '<span>' . htmlspecialchars(format_duration($nextTime));
+                            if ($nextBaseTime !== $nextTime) {
+                                echo ' <small>(base ' . htmlspecialchars(format_duration($nextBaseTime)) . ')</small>';
+                            }
+                            echo '</span></li>';
                             echo '</ul>';
                             echo '</div>';
                             if (!($item['requirements']['ok'] ?? true)) {


### PR DESCRIPTION
## Summary
- compute and expose base construction times for buildings and research alongside accelerated values
- show the base duration hint in colony and research templates and reuse it in async card updates
- update front-end helpers and tests to handle optional base durations in cost lists

## Testing
- composer test
- node --test public/assets/js/__tests__/card-updates.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cff781537c8332be8a5c7e1d7c5119