### PR TITLE
Adjust galaxy controller to handle 16 slots

### DIFF
--- a/src/Controller/GalaxyController.php
+++ b/src/Controller/GalaxyController.php
@@ -185,7 +185,7 @@ class GalaxyController extends AbstractController
      * @param array<int, array{id: int, name: string}> $owners
      * @return array<int, array<string, mixed>>
      *
-     * Je construis les 15 cases du système avec toutes les infos utiles.
+     * Je construis les 16 cases du système avec toutes les infos utiles.
      */
     private function buildSlots(
         array $systemPlanets,
@@ -204,7 +204,7 @@ class GalaxyController extends AbstractController
 
         $needle = mb_strtolower($searchTerm);
         $slots = [];
-        for ($position = 1; $position <= 15; ++$position) {
+        for ($position = 1; $position <= 16; ++$position) {
             $planet = $positionMap[$position] ?? null;
             $coordinates = sprintf('%d:%d:%d', $galaxy, $system, $position);
 


### PR DESCRIPTION
## Summary
- update GalaxyController buildSlots to construct 16 positions instead of 15
- refresh the related docblock comment to describe the new slot count

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cffb4f79cc833294de5ace5daf7ee9