### PR TITLE
Remove obsolete galaxy slot stats markup

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -1108,30 +1108,6 @@ main.workspace__content {
     color: var(--color-text);
 }
 
-.galaxy-slot__stats {
-    margin: 0;
-    display: grid;
-    gap: var(--space-1);
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    font-size: var(--font-size-sm);
-}
-
-.galaxy-slot__stats dt {
-    color: var(--color-muted);
-}
-
-.galaxy-slot__stats dd {
-    margin: 0;
-    color: var(--color-text);
-    font-variant-numeric: tabular-nums;
-}
-
-.galaxy-slot__activity {
-    margin: 0;
-    font-size: var(--font-size-sm);
-    color: var(--color-muted);
-}
-
 .galaxy-slot__empty {
     margin: 0;
     font-size: var(--font-size-sm);

--- a/templates/pages/galaxy/index.php
+++ b/templates/pages/galaxy/index.php
@@ -152,23 +152,6 @@ ob_start();
                 }
                 echo '</div>';
 
-                echo '<dl class="galaxy-slot__stats">';
-                $resources = [
-                    'metal' => 'Métal',
-                    'crystal' => 'Cristal',
-                    'hydrogen' => 'Hydrogène',
-                    'energy' => 'Énergie',
-                ];
-                foreach ($resources as $key => $label) {
-                    $value = (int) ($slot['production'][$key] ?? 0);
-                    $prefix = $key === 'energy' ? '' : ($value >= 0 ? '+' : '');
-                    echo '<div><dt>' . htmlspecialchars($label) . '</dt><dd>' . $prefix . format_number($value) . '/h</dd></div>';
-                }
-                echo '</dl>';
-
-                if (!empty($slot['lastActivity']) && $slot['lastActivity'] instanceof DateTimeImmutable) {
-                    echo '<p class="galaxy-slot__activity">Dernière activité ' . htmlspecialchars(format_relative_time($slot['lastActivity'], $now)) . '</p>';
-                }
             }
 
             echo '</div>';


### PR DESCRIPTION
## Summary
- stop rendering the resource stats list and activity paragraph for occupied galaxy slots
- delete the unused CSS targeting the removed markup

## Testing
- npm run lint:css

------
https://chatgpt.com/codex/tasks/task_e_68cffb50785483328bac54cb5814123e