### PR TITLE
Refactor tech tree data into grouped hierarchy

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -1090,6 +1090,7 @@ const initTechTree = () => {
     const dataElement = document.getElementById('tech-tree-data');
     const detailContainer = document.getElementById('tech-tree-detail');
     const nodeLinks = Array.from(document.querySelectorAll('.tech-node-link[data-tech-target]'));
+    const linkContext = new Map();
 
     if (!dataElement || !detailContainer || nodeLinks.length === 0) {
         return;
@@ -1156,12 +1157,25 @@ const initTechTree = () => {
         const image = imagePath
             ? `<img class="tech-detail__image" src="${escapeHtml(imagePath)}" alt="" loading="lazy" decoding="async">`
             : '';
+        const badgeParts = [];
+        const groupLabel = typeof node.group === 'string' ? node.group.trim() : '';
+        const categoryLabel = typeof node.category === 'string' ? node.category.trim() : '';
+        if (groupLabel !== '') {
+            badgeParts.push(groupLabel);
+        }
+        if (categoryLabel !== '' && categoryLabel !== groupLabel) {
+            badgeParts.push(categoryLabel);
+        }
+        const badgeLabel = badgeParts.join(' • ');
+        const badge = badgeLabel
+            ? `<span class="tech-detail__badge">${escapeHtml(badgeLabel)}</span>`
+            : '';
 
         detailContainer.innerHTML = `
             <article class="tech-detail">
                 ${image}
                 <div class="tech-detail__header">
-                    <span class="tech-detail__badge">${escapeHtml(node.category)}</span>
+                    ${badge}
                     <h2>${escapeHtml(node.label)}</h2>
                     ${levelInfo}
                 </div>
@@ -1174,14 +1188,65 @@ const initTechTree = () => {
         `;
     };
 
+    const openDetail = (detail) => {
+        if (!detail || typeof detail !== 'object') {
+            return;
+        }
+
+        const element = detail;
+        if (typeof element.tagName !== 'string' || element.tagName.toLowerCase() !== 'details') {
+            return;
+        }
+
+        if (!element.open) {
+            element.open = true;
+        }
+
+        const parentContainer = element.parentElement;
+        if (!parentContainer) {
+            return;
+        }
+
+        const parentDetail = parentContainer.closest('details');
+        if (parentDetail && parentDetail !== element) {
+            openDetail(parentDetail);
+        }
+    };
+
     const activateNode = (nodeId) => {
-        nodeLinks.forEach((link) => {
-            link.classList.toggle('is-active', link.dataset.techTarget === nodeId);
+        linkContext.forEach(({ link }, key) => {
+            if (link instanceof HTMLElement) {
+                link.classList.toggle('is-active', key === nodeId);
+            }
         });
+
+        const context = linkContext.get(nodeId);
+        if (context) {
+            openDetail(context.categoryDetail);
+            openDetail(context.groupDetail);
+        }
+
         renderNode(nodeId);
     };
 
     nodeLinks.forEach((link) => {
+        if (!(link instanceof HTMLElement)) {
+            return;
+        }
+
+        const targetId = link.dataset.techTarget || '';
+        if (targetId === '') {
+            return;
+        }
+
+        const categoryDetail = link.closest('details[data-tech-category]');
+        const groupDetail = link.closest('details[data-tech-group]');
+        linkContext.set(targetId, {
+            link,
+            categoryDetail,
+            groupDetail,
+        });
+
         link.classList.toggle('tech-node-link--ready', link.dataset.techReady === '1');
         link.addEventListener('click', () => {
             const target = link.dataset.techTarget || '';

--- a/src/Controller/TechTreeController.php
+++ b/src/Controller/TechTreeController.php
@@ -38,7 +38,7 @@ class TechTreeController extends AbstractController
             return $this->render('pages/tech-tree/index.php', [
                 'title' => 'Arbre technologique',
                 'planets' => [],
-                'tree' => ['categories' => []],
+                'tree' => ['groups' => []],
                 'flashes' => $this->flashBag->consume(),
                 'baseUrl' => $this->baseUrl,
                 'currentUserId' => $userId,

--- a/templates/pages/tech-tree/index.php
+++ b/templates/pages/tech-tree/index.php
@@ -4,7 +4,10 @@
 /** @var string $baseUrl URL de base pour les liens. */
 /** @var int|null $selectedPlanetId Identifiant de la planète choisie. */
 $title = $title ?? 'Arbre technologique';
-$categories = $tree['categories'] ?? [];
+$groups = $tree['groups'] ?? [];
+if (!is_array($groups)) {
+    $groups = [];
+}
 $nodes = [];
 $initialNodeId = null;
 if (!function_exists('getTechState')) {
@@ -19,25 +22,94 @@ if (!function_exists('getTechState')) {
         }
 
         return [
-                'met' => $met,
-                'total' => $total,
-                'allMet' => $total === 0 ? true : ($met === $total),
+            'met' => $met,
+            'total' => $total,
+            'allMet' => $total === 0 ? true : ($met === $total),
         ];
     }
 }
-foreach ($categories as $category) {
-    foreach ($category['items'] as $item) {
-        $nodeId = $category['key'] . ':' . $item['key'];
-        $item['state'] = getTechState($item['requires'] ?? []);
-        $item['category'] = $category['label'];
-        $nodes[$nodeId] = $item;
-        if ($initialNodeId === null) {
-            $initialNodeId = $nodeId;
-        }
+$preparedGroups = [];
+foreach ($groups as $group) {
+    if (!is_array($group)) {
+        continue;
     }
+
+    $groupKey = (string) ($group['key'] ?? '');
+    $groupLabel = (string) ($group['label'] ?? '');
+    $rawCategories = $group['categories'] ?? [];
+    if (!is_array($rawCategories)) {
+        continue;
+    }
+
+    $preparedCategories = [];
+    foreach ($rawCategories as $category) {
+        if (!is_array($category)) {
+            continue;
+        }
+
+        $categoryKey = (string) ($category['key'] ?? '');
+        if ($categoryKey === '') {
+            continue;
+        }
+
+        $categoryLabel = (string) ($category['label'] ?? '');
+        $rawItems = $category['items'] ?? [];
+        if (!is_array($rawItems)) {
+            continue;
+        }
+
+        $preparedItems = [];
+        foreach ($rawItems as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $itemKey = (string) ($item['key'] ?? '');
+            if ($itemKey === '') {
+                continue;
+            }
+
+            $nodeId = $categoryKey . ':' . $itemKey;
+            $state = getTechState($item['requires'] ?? []);
+            $itemData = $item;
+            $itemData['state'] = $state;
+            $itemData['category'] = $categoryLabel;
+            $itemData['group'] = $groupLabel;
+            $itemData['categoryKey'] = $categoryKey;
+            $itemData['groupKey'] = $groupKey;
+            $nodes[$nodeId] = $itemData;
+            if ($initialNodeId === null) {
+                $initialNodeId = $nodeId;
+            }
+
+            $preparedItems[] = $item;
+        }
+
+        if ($preparedItems === []) {
+            continue;
+        }
+
+        $preparedCategories[] = [
+            'key' => $categoryKey,
+            'label' => $categoryLabel,
+            'items' => $preparedItems,
+        ];
+    }
+
+    if ($preparedCategories === []) {
+        continue;
+    }
+
+    $preparedGroups[] = [
+        'key' => $groupKey,
+        'label' => $groupLabel,
+        'categories' => $preparedCategories,
+    ];
 }
+$groups = $preparedGroups;
 $nodesJson = json_encode($nodes, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
 $nodesJson = $nodesJson !== false ? $nodesJson : '{}';
+$hasNodes = !empty($nodes);
 ob_start();
 ?>
     <section class="page-header">
@@ -52,7 +124,7 @@ ob_start();
         </div>
     </section>
 
-<?php if (empty($categories)): ?>
+<?php if (!$hasNodes): ?>
     <article class="panel">
         <div class="panel__body">
             <p>Aucune donnée technologique disponible pour cette planète.</p>
@@ -62,26 +134,56 @@ ob_start();
     <section class="tech-tree" data-base-url="<?= htmlspecialchars($baseUrl) ?>">
         <div class="tech-tree__layout">
             <aside class="tech-tree__sidebar">
-                <?php foreach ($categories as $category): ?>
-                    <details class="tech-section">
+                <?php foreach ($groups as $group): ?>
+                    <?php $groupKey = (string) ($group['key'] ?? ''); ?>
+                    <?php $groupLabel = (string) ($group['label'] ?? ''); ?>
+                    <?php $categories = $group['categories'] ?? []; ?>
+                    <?php if (empty($categories)) { continue; } ?>
+                    <details class="tech-section tech-section--group" data-tech-group="<?= htmlspecialchars($groupKey) ?>">
                         <summary class="tech-section__summary">
-                            <span class="tech-section__title" role="heading" aria-level="2"><?= htmlspecialchars($category['label']) ?></span>
+                            <span class="tech-section__title" role="heading" aria-level="2"><?= htmlspecialchars($groupLabel) ?></span>
                             <span class="tech-section__icon" aria-hidden="true"></span>
                         </summary>
-                        <ul class="tech-section__list">
-                            <?php foreach ($category['items'] as $item): ?>
-                                <?php $nodeId = $category['key'] . ':' . $item['key']; ?>
-                                <?php $state = getTechState($item['requires'] ?? []); ?>
-                                <li>
-                                    <button class="tech-node-link<?= $state['allMet'] ? ' tech-node-link--ready' : '' ?>" type="button" data-tech-target="<?= htmlspecialchars($nodeId) ?>" data-tech-ready="<?= $state['allMet'] ? '1' : '0' ?>">
-                                        <span class="tech-node-link__label"><?= htmlspecialchars($item['label']) ?></span>
-                                        <?php if (isset($item['level'])): ?>
-                                            <span class="tech-node-link__level">Niveau <?= number_format((int) $item['level']) ?></span>
-                                        <?php endif; ?>
-                                    </button>
-                                </li>
+                        <div class="tech-section__groups">
+                            <?php foreach ($categories as $category): ?>
+                                <?php $categoryKey = (string) ($category['key'] ?? ''); ?>
+                                <?php $categoryLabel = (string) ($category['label'] ?? ''); ?>
+                                <?php $items = $category['items'] ?? []; ?>
+                                <?php if (empty($items)) { continue; } ?>
+                                <details class="tech-subsection" data-tech-category="<?= htmlspecialchars($categoryKey) ?>">
+                                    <summary class="tech-subsection__summary">
+                                        <span class="tech-subsection__title" role="heading" aria-level="3"><?= htmlspecialchars($categoryLabel) ?></span>
+                                        <span class="tech-subsection__icon" aria-hidden="true"></span>
+                                    </summary>
+                                    <ul class="tech-section__list tech-section__list--nested">
+                                        <?php foreach ($items as $item): ?>
+                                            <?php $itemKey = (string) ($item['key'] ?? ''); ?>
+                                            <?php if ($itemKey === '') {
+                                                continue;
+                                            } ?>
+                                            <?php $nodeId = $categoryKey . ':' . $itemKey; ?>
+                                            <?php $node = $nodes[$nodeId] ?? null; ?>
+                                            <?php $state = $node['state'] ?? getTechState($item['requires'] ?? []); ?>
+                                            <li>
+                                                <button
+                                                    class="tech-node-link<?= !empty($state['allMet']) ? ' tech-node-link--ready' : '' ?>"
+                                                    type="button"
+                                                    data-tech-target="<?= htmlspecialchars($nodeId) ?>"
+                                                    data-tech-ready="<?= !empty($state['allMet']) ? '1' : '0' ?>"
+                                                    data-tech-group="<?= htmlspecialchars($groupKey) ?>"
+                                                    data-tech-category="<?= htmlspecialchars($categoryKey) ?>"
+                                                >
+                                                    <span class="tech-node-link__label"><?= htmlspecialchars($item['label'] ?? $itemKey) ?></span>
+                                                    <?php if (isset($item['level'])): ?>
+                                                        <span class="tech-node-link__level">Niveau <?= number_format((int) $item['level']) ?></span>
+                                                    <?php endif; ?>
+                                                </button>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </details>
                             <?php endforeach; ?>
-                        </ul>
+                        </div>
                     </details>
                 <?php endforeach; ?>
             </aside>


### PR DESCRIPTION
## Summary
- restructure the GetTechTree use case to expose buildings, ships and research in grouped categories
- update the tech tree template to render nested details per group/category and keep node metadata for the viewer
- adjust the frontend initializer to handle the extra hierarchy, open parent panels and show combined badges

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d008cc64d88332b78d7f8017f85ba4